### PR TITLE
Upgrade Rollbar maybe

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "request": "^2.81.0",
     "request-promise-native": "^1.0.3",
     "resolve-url-loader": "^3.0.0",
-    "rollbar": "^2.1.3",
+    "rollbar": "^2.19.4",
     "sass-loader": "^7.0.1",
     "semantic-ui-css": "^2.2.4",
     "semantic-ui-react": "^0.87.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,7 +3138,7 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@^1.0.0, buffer-from@~1.1.1:
+buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -9627,15 +9627,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollbar@^2.1.3:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.15.0.tgz#1291116a2b6273a22f2e4b5d1b3eb9880e1b5dac"
-  integrity sha512-imEL4FOng650XZq0ZoqAI8wCfWZ5UE+4rRJwwwxthyzTdKOeDAObz/trMohc/ULn1WCo9Cz3T6ozn9Awd5kGTg==
+rollbar@^2.19.4:
+  version "2.19.4"
+  resolved "https://registry.yarnpkg.com/rollbar/-/rollbar-2.19.4.tgz#eda4145cb459203bd3e9ccd885bfb5c5c3f6f2a2"
+  integrity sha512-8ErcMfJE2zkhgrFtpGRyejHBhyO0hU7dZ3EvG2ylNZ7qSu4yw5PZfhGx+Qyq3ksKshLFeQh9Y/Bh2S1TOPIhvw==
   dependencies:
     async "~1.2.1"
-    buffer-from "~1.1.1"
     console-polyfill "0.3.0"
-    debug "2.6.9"
     error-stack-parser "^2.0.4"
     json-stringify-safe "~5.0.0"
     lru-cache "~2.2.1"


### PR DESCRIPTION
bakcend server is not talking to rollbar properly, particularly on uncaught exceptions. trying to use the rollbar's own `captureUncaught` instead of our own wack stuff in hopes that it'll help. Also upgraded rollbar version
