### PR TITLE
Bug When Search Course No Sections

### DIFF
--- a/backend/searcher.ts
+++ b/backend/searcher.ts
@@ -262,7 +262,7 @@ class Searcher {
     return {
       nupath: result.nupath.map((val) => { return { value: val, count: 1 } }),
       subject: [{ value: result.subject, count: 1 }],
-      classType: [{ value: result.sections[0].classType, count: 1 }],
+      classType: result.sections[0] ? [{ value: result.sections[0].classType, count: 1 }] : [],
     };
   }
 
@@ -281,17 +281,17 @@ class Searcher {
     // if we know that the query is of the format of a course code, we want to return only one result
     const patternResults = query.match(this.COURSE_CODE_PATTERN);
     const subject = patternResults ? patternResults[1].toUpperCase() : '';
-    // if (patternResults && macros.isNumeric(patternResults[2]) && (this.getSubjects()).has(subject)) {
-    //   ({
-    //     results, resultCount, took, hydrateDuration, aggregations,
-    //   } = await this.getOneSearchResult(subject, patternResults[2], termId));
-    // } else {
-    const searchResults = await this.getSearchResults(query, termId, min, max, filters);
-    ({ resultCount, took, aggregations } = searchResults);
-    const startHydrate = Date.now();
-    results = await (new HydrateSerializer()).bulkSerialize(searchResults.output);
-    hydrateDuration = Date.now() - startHydrate;
-    // }
+    if (patternResults && macros.isNumeric(patternResults[2]) && (this.getSubjects()).has(subject)) {
+      ({
+        results, resultCount, took, hydrateDuration, aggregations,
+      } = await this.getOneSearchResult(subject, patternResults[2], termId));
+    } else {
+      const searchResults = await this.getSearchResults(query, termId, min, max, filters);
+      ({ resultCount, took, aggregations } = searchResults);
+      const startHydrate = Date.now();
+      results = await (new HydrateSerializer()).bulkSerialize(searchResults.output);
+      hydrateDuration = Date.now() - startHydrate;
+    }
     return {
       searchContent: results,
       resultCount,


### PR DESCRIPTION
# What
Server crashes when people do a single search result for a course with no sections

# Why
To get aggregation information for a single search result, we assumed there'd be at least one section and tried to get the class type of the first section.

# Fix
Added a check in method that gets aggregation: if there's no section for that course, the classType aggregation is an empty array

# Questions
Should a single search result even show up if there are no sections? Right now, if we search "ARTG 5100" in the Spring, we see the course information but no sections (looks a bit odd).

<img width="1680" alt="Screen Shot 2020-11-16 at 3 01 45 PM" src="https://user-images.githubusercontent.com/55663526/99301998-c38e2480-281c-11eb-850e-677d0ae244e8.png">
