### PR TITLE
Don't blow up on new follows for sections or courses

### DIFF
--- a/backend/database.ts
+++ b/backend/database.ts
@@ -22,12 +22,34 @@ class Database {
     await Promise.all([prisma.followedSection.deleteMany({ where: { userId: key } }), prisma.followedCourse.deleteMany({ where: { userId: key } })]);
 
     if (value.watchingSections) {
-      await Promise.all(value.watchingSections.map((section) => { return prisma.followedSection.create({ data: { user: { connect: { id: key } }, section: { connect: { id: section } } } }); }));
+      await Promise.all(value.watchingSections.map((section) => this.createFollowedSection(key, section)));
     }
 
     if (value.watchingClasses) {
-      await Promise.all(value.watchingClasses.map((course) => { return prisma.followedCourse.create({ data: { user: { connect: { id: key } }, course: { connect: { id: course } } } }); }));
+      await Promise.all(value.watchingClasses.map((course) => this.createFollowedCourse(key, course)));
     }
+  }
+
+  async createFollowedCourse(userId: string, courseId: string) {
+    return prisma.followedCourse.upsert({
+      where: { userId_courseId: { userId, courseId } },
+      create: {
+        user: { connect: { id: userId } },
+        course: { connect: { id: courseId } },
+      },
+      update: {}
+    });
+  }
+
+  async createFollowedSection(userId: string, sectionId: string) {
+    return prisma.followedSection.upsert({
+      where: { userId_sectionId: { userId, sectionId } },
+      create: {
+        user: { connect: { id: userId } },
+        section: { connect: { id: sectionId } },
+      },
+      update: {}
+    });
   }
 
   // Get the value at this key.

--- a/backend/database.ts
+++ b/backend/database.ts
@@ -37,7 +37,7 @@ class Database {
         user: { connect: { id: userId } },
         course: { connect: { id: courseId } },
       },
-      update: {}
+      update: {},
     });
   }
 
@@ -48,7 +48,7 @@ class Database {
         user: { connect: { id: userId } },
         section: { connect: { id: sectionId } },
       },
-      update: {}
+      update: {},
     });
   }
 

--- a/backend/tests/database.test.seq.ts
+++ b/backend/tests/database.test.seq.ts
@@ -152,7 +152,7 @@ describe('set', () => {
   it('does not blow up if the same course is followed multiple times', async () => {
     expect(((await prisma.followedCourse.findMany({ where: { userId: '123456789' } }))[0]).courseId).toBe('neu.edu/202030/CS/3500');
     await database.set('123456789', {
-      watchingClasses: ['neu.edu/202030/CS/3500', 'neu.edu/202030/CS/2500']
+      watchingClasses: ['neu.edu/202030/CS/3500', 'neu.edu/202030/CS/2500'],
     });
 
     expect(await prisma.followedCourse.count({ where: { userId: '123456789', courseId: 'neu.edu/202030/CS/3500' } })).toBe(1);

--- a/backend/tests/database.test.seq.ts
+++ b/backend/tests/database.test.seq.ts
@@ -148,6 +148,28 @@ describe('set', () => {
     expect(await prisma.followedCourse.count({ where: { userId: '123456789', courseId: 'neu.edu/202030/CS/2510' } })).toBe(1);
     expect(await prisma.followedCourse.count({ where: { userId: '123456789' } })).toBe(2);
   });
+
+  it('does not blow up if the same course is followed multiple times', async () => {
+    expect(((await prisma.followedCourse.findMany({ where: { userId: '123456789' } }))[0]).courseId).toBe('neu.edu/202030/CS/3500');
+    await database.set('123456789', {
+      watchingClasses: ['neu.edu/202030/CS/3500', 'neu.edu/202030/CS/2500']
+    });
+
+    expect(await prisma.followedCourse.count({ where: { userId: '123456789', courseId: 'neu.edu/202030/CS/3500' } })).toBe(1);
+    expect(await prisma.followedCourse.count({ where: { userId: '123456789', courseId: 'neu.edu/202030/CS/2500' } })).toBe(1);
+    expect(await prisma.followedCourse.count({ where: { userId: '123456789' } })).toBe(2);
+  });
+
+  it('does not blow up if the same section is followed multiple times', async () => {
+    expect(((await prisma.followedSection.findMany({ where: { userId: '123456789' } }))[0]).sectionId).toBe('neu.edu/202030/CS/2500/19350');
+    await database.set('123456789', {
+      watchingSections: ['neu.edu/202030/CS/2500/19350', 'neu.edu/202030/CS/3500/20350'],
+    });
+
+    expect(await prisma.followedSection.count({ where: { userId: '123456789', sectionId: 'neu.edu/202030/CS/2500/19350' } })).toBe(1);
+    expect(await prisma.followedSection.count({ where: { userId: '123456789', sectionId: 'neu.edu/202030/CS/3500/20350' } })).toBe(1);
+    expect(await prisma.followedSection.count({ where: { userId: '123456789' } })).toBe(2);
+  });
 });
 
 describe('get', () => {


### PR DESCRIPTION
Right now, if a student ever tries to follow more than one section or course, _searchneu goes down_. 

The solution is to just upsert `followedCourses` or `followedSections` instead of inserting them, so nothing blows up on conflict.

Need to test this locally before release.