### PR TITLE
Change the Update Times listed on Search Results

### DIFF
--- a/backend/dumpProcessor.ts
+++ b/backend/dumpProcessor.ts
@@ -131,6 +131,7 @@ class DumpProcessor {
       await prisma.course.deleteMany({
         where: {
           termId: { in: Array.from(coveredTerms) },
+          // delete all courses that haven't been updated in the past 2 days (in milliseconds)
           lastUpdateTime: { lt: new Date(new Date().getTime() - 48 * 60 * 60 * 1000) },
         },
       });

--- a/backend/dumpProcessor.ts
+++ b/backend/dumpProcessor.ts
@@ -127,6 +127,19 @@ class DumpProcessor {
 
     macros.log('finished with sections');
 
+    const courseUpdateTimes: Record<string, Date> = processedSections.reduce((acc: Record<string, Date>, section) => {
+      return { ...acc, [section.classHash]: new Date() };
+    }, {});
+
+    await Promise.all(Object.entries(courseUpdateTimes).map(async ([id, updateTime]) => {
+      return prisma.course.update({
+        where: { id },
+        data: { lastUpdateTime: updateTime },
+      });
+    }));
+
+    macros.log('finished updating times');
+
     if (destroy) {
       await prisma.course.deleteMany({
         where: {

--- a/frontend/components/classModels/Course.ts
+++ b/frontend/components/classModels/Course.ts
@@ -347,9 +347,7 @@ class Course {
   }
 
   getLastUpdateString() : string {
-    const sectionLastUpdateTimes: number[] = this.sections.map((section) => section.lastUpdateTime);
-    const minLastUpdateTime: number = Math.min(this.lastUpdateTime, ...sectionLastUpdateTimes);
-    return minLastUpdateTime ? moment(minLastUpdateTime).fromNow() : null;
+    return this.lastUpdateTime ? moment(this.lastUpdateTime).fromNow() : null;
   }
 
   //returns true if any sections have an exam, else false

--- a/frontend/components/classModels/Course.ts
+++ b/frontend/components/classModels/Course.ts
@@ -347,7 +347,9 @@ class Course {
   }
 
   getLastUpdateString() : string {
-    return this.lastUpdateTime ? moment(this.lastUpdateTime).fromNow() : null;
+    const sectionLastUpdateTimes: number[] = this.sections.map((section) => section.lastUpdateTime);
+    const minLastUpdateTime: number = Math.min(this.lastUpdateTime, ...sectionLastUpdateTimes);
+    return minLastUpdateTime ? moment(minLastUpdateTime).fromNow() : null;
   }
 
   //returns true if any sections have an exam, else false


### PR DESCRIPTION
Right now, the `last updated time` listed on search results is the last time the course was scraped. This isn't indicative of the last time the seat count was updated though, which is causing some users to lose trust in the numbers we display. 

This PR changes the number to the last time the seat counts were changed.