### PR TITLE
Fix tests on staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,9 +229,6 @@
     "setupFiles": [
       "./common/jestSetupFile.js"
     ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/common/teardown.ts"
-    ],
     "moduleFileExtensions": [
       "js",
       "jsx",

--- a/package.json
+++ b/package.json
@@ -229,7 +229,6 @@
     "setupFiles": [
       "./common/jestSetupFile.js"
     ],
-    "setupFilesAfterEnv": ["<rootDir>/common/teardown.ts"],
     "moduleFileExtensions": [
       "js",
       "jsx",

--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
     "setupFiles": [
       "./common/jestSetupFile.js"
     ],
+    "setupFilesAfterEnv": ["<rootDir>/common/teardown.ts"],
     "moduleFileExtensions": [
       "js",
       "jsx",


### PR DESCRIPTION
All tests on staging were blowing up, due to a `prisma` update. There shouldn't have been any reference to prisma in non-database tests, but there was one (in teardown for regular tests) that was unnecessary, which I removed.