### PR TITLE
Single Search Result Subject Description

### DIFF
--- a/backend/searcher.ts
+++ b/backend/searcher.ts
@@ -279,7 +279,7 @@ class Searcher {
   getSingleResultAggs(result: CourseWithSections) : AggResults {
     return {
       nupath: result.nupath.map((val) => { return { value: val, count: 1 } }),
-      subject: [{ value: result.subject, count: 1 }],
+      subject: [this.generateAgg('subject', result.subject, 1)],
       classType: [{ value: result.sections[0].classType, count: 1 }],
       campus: [{ value: result.sections[0].campus, count: 1 }],
     };


### PR DESCRIPTION
# what
Single search result doesn't show subject description

# why
Aggregation generation is different for single search result compared to normal searches

# fix
Called helper function for aggregation generation for subject filter