### PR TITLE
Bug Rendering Prereqs

### DIFF
--- a/frontend/components/ResultsPage/Results/useResultDetail.tsx
+++ b/frontend/components/ResultsPage/Results/useResultDetail.tsx
@@ -131,9 +131,9 @@ export default function useResultDetail(aClass: Course) {
     } else {
       let type;
       if (reqType === macros.prereqTypes.PREREQ) {
-        type = aClass.prereqs.type;
+        type = course.prereqs.type;
       } else if (reqType === macros.prereqTypes.COREQ) {
-        type = aClass.coreqs.type;
+        type = course.coreqs.type;
       }
       for (let i = retVal.length - 1; i >= 1; i--) {
         retVal.splice(i, 0, ` ${type} `);
@@ -147,7 +147,6 @@ export default function useResultDetail(aClass: Course) {
         </span>
       );
     }
-
     return retVal;
   }
 


### PR DESCRIPTION
# what
Prereqs were improperly displayed. CS4500 should have prereqs: (ENGW 1102 or ENGW 1111) and CS 3500
but results were  (ENGW 1102 and ENGW 1111) and CS 3500

# fix
The backend was fine, the frontend just didn't render the type of nested prereqs correctly.