### PR TITLE
No Notifications For Old Courses

### DIFF
--- a/frontend/components/ResultsPage/Results/SearchResult.tsx
+++ b/frontend/components/ResultsPage/Results/SearchResult.tsx
@@ -64,7 +64,7 @@ export default function SearchResult({ aClass } : SearchResultProps) {
             {feeString ? <span>  {feeString}</span> : <span className='empty'> None</span>}
           </div>
           <div className='SearchResult__panel--right'>
-            { notMostRecentTerm(aClass.termId) ? '' : <SignUpForNotifications aClass={ aClass } userIsWatchingClass={ userIsWatchingClass } />}
+            { notMostRecentTerm(aClass.termId) ? undefined : <SignUpForNotifications aClass={ aClass } userIsWatchingClass={ userIsWatchingClass } />}
           </div>
         </div>
       </div>

--- a/frontend/components/ResultsPage/Results/SearchResult.tsx
+++ b/frontend/components/ResultsPage/Results/SearchResult.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Markup } from 'interweave'
 import { DropdownItemProps } from 'semantic-ui-react'
+import _ from 'lodash';
 import macros from '../../macros'
 import DesktopSectionPanel from './DesktopSectionPanel'
 import Course from '../../classModels/Course'
@@ -20,18 +21,14 @@ interface SearchResultProps {
 }
 
 function greaterTermExists(dropdownOptions : DropdownItemProps[], termId : number) : boolean {
-  let greaterTermFound = false;
-  dropdownOptions.forEach((option) => {
+  return _.some(dropdownOptions, (option) => {
     const diff = Number(option.value) - termId;
-    if (diff > 0 && diff % 10 === 0) {
-      greaterTermFound = true;
-    }
+    return diff > 0 && diff % 10 === 0;
   })
-  return greaterTermFound;
 }
 
 function notMostRecentTerm(termId: string) : boolean {
-  const campus = getCampusByLastDigit(termId.substring(termId.length - 1, termId.length));
+  const campus = getCampusByLastDigit(termId.charAt(termId.length - 1));
   const termIdNum = Number(termId);
   switch (campus) {
     case Campus.NEU:

--- a/frontend/components/ResultsPage/Results/SearchResult.tsx
+++ b/frontend/components/ResultsPage/Results/SearchResult.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import { Markup } from 'interweave'
-import { DropdownItemProps } from 'semantic-ui-react'
-import _ from 'lodash';
 import macros from '../../macros'
 import DesktopSectionPanel from './DesktopSectionPanel'
 import Course from '../../classModels/Course'
@@ -11,35 +9,10 @@ import SignUpForNotifications from '../../SignUpForNotifications'
 import useResultDetail from './useResultDetail'
 import useUserChange from './useUserChange';
 import useShowAll from './useShowAll';
-import { Campus } from '../../types';
-import {
-  neuTermDropdownOptions, cpsTermDropdownOptions, lawTermDropdownOptions, getCampusByLastDigit,
-} from '../../global';
+import { notMostRecentTerm } from '../../global';
 
 interface SearchResultProps {
   aClass: Course,
-}
-
-function greaterTermExists(dropdownOptions : DropdownItemProps[], termId : number) : boolean {
-  return _.some(dropdownOptions, (option) => {
-    const diff = Number(option.value) - termId;
-    return diff > 0 && diff % 10 === 0;
-  })
-}
-
-function notMostRecentTerm(termId: string) : boolean {
-  const campus = getCampusByLastDigit(termId.charAt(termId.length - 1));
-  const termIdNum = Number(termId);
-  switch (campus) {
-    case Campus.NEU:
-      return greaterTermExists(neuTermDropdownOptions, termIdNum);
-    case Campus.CPS:
-      return greaterTermExists(cpsTermDropdownOptions, termIdNum);
-    case Campus.LAW:
-      return greaterTermExists(lawTermDropdownOptions, termIdNum);
-    default:
-      throw new Error('Unrecognized campus type.');
-  }
 }
 
 export default function SearchResult({ aClass } : SearchResultProps) {

--- a/frontend/components/global.ts
+++ b/frontend/components/global.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { DropdownItemProps } from 'semantic-ui-react';
 import { Campus } from './types';
 
@@ -86,6 +87,28 @@ export function getCampusByLastDigit(t: string): Campus {
       return Campus.CPS;
     default:
       throw new Error('unexpected campus digit');
+  }
+}
+
+export function greaterTermExists(dropdownOptions : DropdownItemProps[], termId : number) : boolean {
+  return _.some(dropdownOptions, (option) => {
+    const diff = Number(option.value) - termId;
+    return diff > 0 && diff % 10 === 0;
+  })
+}
+
+export function notMostRecentTerm(termId: string) : boolean {
+  const campus = getCampusByLastDigit(termId.charAt(termId.length - 1));
+  const termIdNum = Number(termId);
+  switch (campus) {
+    case Campus.NEU:
+      return greaterTermExists(neuTermDropdownOptions, termIdNum);
+    case Campus.CPS:
+      return greaterTermExists(cpsTermDropdownOptions, termIdNum);
+    case Campus.LAW:
+      return greaterTermExists(lawTermDropdownOptions, termIdNum);
+    default:
+      throw new Error('Unrecognized campus type.');
   }
 }
 


### PR DESCRIPTION
# what
Users had the option to sign up for notifications when seats open up in courses from previous terms

# fix
Use the termId of courses to determine if there's a newer termId. If so, don't show option to sign up for notification.