### PR TITLE
Get Scrapers Working

### DIFF
--- a/backend/scrapers/request.js
+++ b/backend/scrapers/request.js
@@ -75,6 +75,9 @@ const separateReqPools = {
   // Usually takes just under 1 hr at 1k sockets and the same timeouts.
   // Took around 20 min with timeouts set to 100ms and 150ms and 100 sockets.
   'wl11gp.neu.edu':  { maxSockets: 100, keepAlive: true, maxFreeSockets: 100 },
+
+  // Increase the number of sockets for Banner v9
+  'nubanner.neu.edu': { maxSockets: 100, keepAlive: true, maxFreeSockets: 100 },
 };
 
 // Enable the DNS cache. This module replaces the .lookup method on the built in dns module to cache lookups.


### PR DESCRIPTION
# What
Scrapers fail on prod and for a number of local machines, so want to get it _passing_ (virtually no matter the cost--we'll add back features and clean up code later).

# How
1. Improving performance by doubling the number of open connections and having the number of simultaneous requests equal to the number of possible open connections (potentially reduce thrashing).
2. Don't search for classes referenced in `reqs`. It seemed to be the root cause of the failures.

# Notes
1. Want to bring the deleted feature back later.
2. We need a new request system that at least logs more expressively. Our request infrastructure may also need a revamp. The code is quite bad.