### PR TITLE
Fix Frontend Rendering of Min/Max Credits

### DIFF
--- a/components/ResultsPage/Results/useResultDetail.tsx
+++ b/components/ResultsPage/Results/useResultDetail.tsx
@@ -218,7 +218,7 @@ export default function useResultDetail(
       aClass.maxCredits > 1 || aClass.maxCredits === 0 ? 'CREDITS' : 'CREDIT';
     return aClass.maxCredits === aClass.minCredits
       ? `${aClass.maxCredits} ${creditDescriptor}`
-      : `${aClass.maxCredits}-${aClass.maxCredits} ${creditDescriptor}`;
+      : `${aClass.minCredits}-${aClass.maxCredits} ${creditDescriptor}`;
   };
 
   return {


### PR DESCRIPTION
# what 
When min credits and max credits are different for a class, the frontend would render something like `1-1 Credits` which is wrong

# fix
Render `minCredits - maxCredits` if values are different