### PR TITLE
faster results page

### DIFF
--- a/components/ResultsPage/useSearch.ts
+++ b/components/ResultsPage/useSearch.ts
@@ -59,6 +59,10 @@ export default function useSearch({
   filters,
 }: SearchParams): UseSearchReturn {
   const getKey = (pageIndex: number): string => {
+    if (!termId) {
+      // don't make the request until data is good
+      return null;
+    }
     const nonDefaultFilters = pickBy(
       filters,
       (v, k: keyof FilterSelection) => !isEqual(v, DEFAULT_FILTER_SELECTION[k])

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -35,10 +35,10 @@ exports[`should render a section 1`] = `
           <div className=\\"Breadcrumb_Container\\">
             <div className=\\"Breadcrumb_Container__dropDownContainer\\">
               <Memo(SearchDropdown) options={{...}} value=\\"NEU\\" className=\\"searchDropdown\\" compact={false}>
-                <Dropdown fluid={true} compact={false} text=\\"NEU\\" className=\\"searchDropdown \\" additionLabel=\\"Add \\" additionPosition=\\"top\\" closeOnBlur={true} closeOnEscape={true} deburr={false} icon=\\"dropdown\\" minCharacters={1} noResultsMessage=\\"No results found.\\" openOnFocus={true} renderLabel={[Function: renderItemContent]} searchInput=\\"text\\" selectOnBlur={true} selectOnNavigation={true} wrapSelection={true}>
+                <Dropdown fluid={true} compact={false} text=\\"NEU\\" className=\\"selection searchDropdown \\" additionLabel=\\"Add \\" additionPosition=\\"top\\" closeOnBlur={true} closeOnEscape={true} deburr={false} icon=\\"dropdown\\" minCharacters={1} noResultsMessage=\\"No results found.\\" openOnFocus={true} renderLabel={[Function: renderItemContent]} searchInput=\\"text\\" selectOnBlur={true} selectOnNavigation={true} wrapSelection={true}>
                   <Ref innerRef={{...}}>
                     <RefFindNode innerRef={{...}}>
-                      <div role=\\"listbox\\" aria-busy={[undefined]} aria-disabled={[undefined]} aria-expanded={false} aria-multiselectable={[undefined]} className=\\"ui fluid dropdown searchDropdown \\" onBlur={[Function (anonymous)]} onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onMouseDown={[Function (anonymous)]} onFocus={[Function (anonymous)]} onChange={[Function (anonymous)]} tabIndex={0}>
+                      <div role=\\"listbox\\" aria-busy={[undefined]} aria-disabled={[undefined]} aria-expanded={false} aria-multiselectable={[undefined]} className=\\"ui fluid dropdown selection searchDropdown \\" onBlur={[Function (anonymous)]} onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onMouseDown={[Function (anonymous)]} onFocus={[Function (anonymous)]} onChange={[Function (anonymous)]} tabIndex={0}>
                         <DropdownText className=\\"text\\" content=\\"NEU\\">
                           <div aria-atomic={true} aria-live=\\"polite\\" role=\\"alert\\" className=\\"divider text\\">
                             NEU
@@ -89,10 +89,10 @@ exports[`should render a section 1`] = `
             </span>
             <div className=\\"Breadcrumb_Container__dropDownContainer\\">
               <Memo(SearchDropdown) options={{...}} value=\\"202160\\" className=\\"searchDropdown\\" compact={false}>
-                <Dropdown fluid={true} compact={false} text=\\"Summer II 2021\\" className=\\"searchDropdown \\" additionLabel=\\"Add \\" additionPosition=\\"top\\" closeOnBlur={true} closeOnEscape={true} deburr={false} icon=\\"dropdown\\" minCharacters={1} noResultsMessage=\\"No results found.\\" openOnFocus={true} renderLabel={[Function: renderItemContent]} searchInput=\\"text\\" selectOnBlur={true} selectOnNavigation={true} wrapSelection={true}>
+                <Dropdown fluid={true} compact={false} text=\\"Summer II 2021\\" className=\\"selection searchDropdown \\" additionLabel=\\"Add \\" additionPosition=\\"top\\" closeOnBlur={true} closeOnEscape={true} deburr={false} icon=\\"dropdown\\" minCharacters={1} noResultsMessage=\\"No results found.\\" openOnFocus={true} renderLabel={[Function: renderItemContent]} searchInput=\\"text\\" selectOnBlur={true} selectOnNavigation={true} wrapSelection={true}>
                   <Ref innerRef={{...}}>
                     <RefFindNode innerRef={{...}}>
-                      <div role=\\"listbox\\" aria-busy={[undefined]} aria-disabled={[undefined]} aria-expanded={false} aria-multiselectable={[undefined]} className=\\"ui fluid dropdown searchDropdown \\" onBlur={[Function (anonymous)]} onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onMouseDown={[Function (anonymous)]} onFocus={[Function (anonymous)]} onChange={[Function (anonymous)]} tabIndex={0}>
+                      <div role=\\"listbox\\" aria-busy={[undefined]} aria-disabled={[undefined]} aria-expanded={false} aria-multiselectable={[undefined]} className=\\"ui fluid dropdown selection searchDropdown \\" onBlur={[Function (anonymous)]} onClick={[Function (anonymous)]} onKeyDown={[Function (anonymous)]} onMouseDown={[Function (anonymous)]} onFocus={[Function (anonymous)]} onChange={[Function (anonymous)]} tabIndex={0}>
                         <DropdownText className=\\"text\\" content=\\"Summer II 2021\\">
                           <div aria-atomic={true} aria-live=\\"polite\\" role=\\"alert\\" className=\\"divider text\\">
                             Summer II 2021

--- a/pages/[campus]/[termId]/search/[query].tsx
+++ b/pages/[campus]/[termId]/search/[query].tsx
@@ -216,10 +216,3 @@ export default function Results(): ReactElement | null {
     </div>
   );
 }
-
-// this prevents Next js static optimization so we don't have a second search query sent to the backend
-export const getServerSideProps: GetServerSideProps = async () => {
-  return {
-    props: {},
-  };
-};


### PR DESCRIPTION
there's a noticeable delay when hitting search from the home page sometimes. I think this has to do with us "server side rendering" the results page with no actual data. On vercel, they have to cold-start the serverless functions which has a multi-second delay. And even when the functions are warm and ready to go, we just shouldn't require a server round-trip just to start rendering the results page.

We did this SSR trick originally to stop static optimization, which was causing us to fetch empty-query results from the backend every initial load. This PR fixes that by telling SWR not to load data when the router info hasn't filled in yet. 

You can see in the preview hitting enter from home page s nearly instantaneous