### PR TITLE
Fix infinite scroll bug when searching exact course

### DIFF
--- a/components/ResultsPage/ResultsLoader.tsx
+++ b/components/ResultsPage/ResultsLoader.tsx
@@ -22,6 +22,7 @@ const DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
 interface ResultsLoaderProps {
   results: SearchItem[];
   loadMore: () => void;
+  hasNextPage: boolean;
 }
 
 const getGroupedByTimeOfDay = (times): DayjsTuple[] => {
@@ -94,12 +95,13 @@ const getFormattedSections = (sections: any): Section[] => {
 function ResultsLoader({
   results,
   loadMore,
+  hasNextPage,
 }: ResultsLoaderProps): ReactElement {
   return (
     <InfiniteScroll
       dataLength={results.length}
       next={loadMore}
-      hasMore
+      hasMore={hasNextPage}
       loader={null}
     >
       <div className="five column row">

--- a/components/ResultsPage/useSearch.ts
+++ b/components/ResultsPage/useSearch.ts
@@ -101,6 +101,7 @@ export default function useSearch({
   const returnedData = data && {
     filterOptions: data[0].filterOptions,
     results: data.map((d) => d.results).flat(),
+    hasNextPage: data[0].hasNextPage,
   };
 
   return {
@@ -115,6 +116,7 @@ function transformGraphQLToSearchResult(
   const transformedResults: SearchResult = {
     results: [],
     filterOptions: graphqlResults.search.filterOptions as FilterOptions,
+    hasNextPage: graphqlResults.search.pageInfo.hasNextPage,
   };
   transformedResults.results = graphqlResults.search.nodes.map((node) => {
     if (node.type === 'ClassOccurrence') {

--- a/components/types.ts
+++ b/components/types.ts
@@ -103,6 +103,7 @@ export interface Meeting {
 export interface SearchResult {
   results: SearchItem[];
   filterOptions: FilterOptions;
+  hasNextPage: boolean;
 }
 
 export type CourseResult = {
@@ -122,6 +123,7 @@ export function BLANK_SEARCH_RESULT(): SearchResult {
       classType: [],
       campus: [],
     },
+    hasNextPage: false,
   };
 }
 

--- a/pages/[campus]/[termId]/search/[query].tsx
+++ b/pages/[campus]/[termId]/search/[query].tsx
@@ -101,7 +101,11 @@ export default function Results(): ReactElement | null {
             />
           )}
           {searchData && searchData.results.length > 0 && (
-            <ResultsLoader results={searchData.results} loadMore={loadMore} />
+            <ResultsLoader
+              results={searchData.results}
+              loadMore={loadMore}
+              hasNextPage={searchData.hasNextPage}
+            />
           )}
           <Footer />
         </div>


### PR DESCRIPTION
# what

Fix the bug where if you search an exact course, and your window is small enough to have a scrollbar, then scrolling down would keep appending that one course to your results infinitely.

# how

Extract the `hasNextPage` flag from search queries and pass that as the `hasMore` prop to the `<InfiniteScroll>` component instead of hardcoding it to true as it was previously.