### PR TITLE
String ClassIds from CCA

### DIFF
--- a/components/ResultsPage/useSearch.ts
+++ b/components/ResultsPage/useSearch.ts
@@ -125,7 +125,6 @@ function transformGraphQLToSearchResult(
         class: {
           ...node,
           termId: node.termId.toString(),
-          classId: node.classId.toString(),
         },
         type: 'class',
       };

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -81,7 +81,7 @@ export type ClassOccurrence = {
   __typename?: 'ClassOccurrence';
   name: Scalars['String'];
   subject: Scalars['String'];
-  classId: Scalars['Int'];
+  classId: Scalars['String'];
   termId: Scalars['Int'];
   desc: Scalars['String'];
   prereqs?: Maybe<Scalars['JSON']>;


### PR DESCRIPTION
This PR goes along with[ this course-catalog-api PR](https://github.com/sandboxnu/course-catalog-api/pull/33).

# what 
course-catalog-api should be sending back string `classIds` instead of ints to avoid converting classes like `ESLG 0045` into `ESLG 45`. Previously, because `classIds` were ints and the Course type definition had string `classIds`, we had to convert the numeric `classId` to a string in `transformGraphQLToSearchResult()`. This is no longer necessary.