### PR TITLE
Style final exams

### DIFF
--- a/components/ResultsPage/Results/SectionPanel.tsx
+++ b/components/ResultsPage/Results/SectionPanel.tsx
@@ -125,7 +125,7 @@ export function DesktopSectionPanel({
 
   const getMeetings = (s: Section): ReactElement[] => {
     // Class meeting times should always come before Final Exam times
-    s.meetings.sort((a, b) => (a.type === MeetingType.CLASS ? -1 : 1));
+    s.meetings.sort((a) => (a.type === MeetingType.CLASS ? -1 : 1));
     return s.meetings.map((m) => {
       const meetingDays = Array(7).fill(false);
       meetingDays.forEach((d, index) => {

--- a/components/ResultsPage/Results/SectionPanel.tsx
+++ b/components/ResultsPage/Results/SectionPanel.tsx
@@ -2,7 +2,13 @@ import dynamic from 'next/dynamic';
 import React, { ReactElement } from 'react';
 import IconGlobe from '../../icons/IconGlobe';
 import Keys from '../../Keys';
-import { DayjsTuple, DayOfWeek, Meeting, Section } from '../../types';
+import {
+  DayjsTuple,
+  DayOfWeek,
+  Meeting,
+  MeetingType,
+  Section,
+} from '../../types';
 import useSectionPanelDetail from './useSectionPanelDetail';
 import WeekdayBoxes from './WeekdayBoxes';
 import Tooltip, { TooltipDirection } from '../../Tooltip';
@@ -83,14 +89,25 @@ export function DesktopSectionPanel({
     if (daysMet.some((d) => d)) {
       return (
         <div className="DesktopSectionPanel__meetings">
-          <WeekdayBoxes meetingDays={daysMet} />
+          <WeekdayBoxes meetingDays={daysMet} meetingType={meeting.type} />
           <div className="DesktopSectionPanel__meetings--times">
             {getUniqueTimes(meeting.times).map((time) => (
               <>
                 <span>
-                  {`${time.start.format('h:mm')}-${time.end.format(
-                    'h:mm a'
-                  )} | ${meeting.location}`}
+                  {meeting.type === MeetingType.FINAL_EXAM ? (
+                    <>
+                      <b>Final Exam</b> |{' '}
+                      {`${time.start.format('h:mm')}-${time.end.format(
+                        'h:mm a'
+                      )} | ${meeting.location} | ${meeting.startDate.format(
+                        'MMM D'
+                      )}`}
+                    </>
+                  ) : (
+                    `${time.start.format('h:mm')}-${time.end.format(
+                      'h:mm a'
+                    )} | ${meeting.location}`
+                  )}
                 </span>
                 <br />
               </>
@@ -107,6 +124,8 @@ export function DesktopSectionPanel({
   };
 
   const getMeetings = (s: Section): ReactElement[] => {
+    // Class meeting times should always come before Final Exam times
+    s.meetings.sort((a, b) => (a.type === MeetingType.CLASS ? -1 : 1));
     return s.meetings.map((m) => {
       const meetingDays = Array(7).fill(false);
       meetingDays.forEach((d, index) => {

--- a/components/ResultsPage/Results/SectionPanel.tsx
+++ b/components/ResultsPage/Results/SectionPanel.tsx
@@ -193,7 +193,11 @@ export function MobileSectionPanel({
   };
 
   const getMeetings = (s: Section): ReactElement[][] => {
-    return s.meetings.map((m) =>
+    // Mobile only displays class times, no final exams
+    const classMeetings = s.meetings.filter(
+      (m) => m.type === MeetingType.CLASS
+    );
+    return classMeetings.map((m) =>
       Array.from(groupedTimesAndDays(m.times)).map(([time, days]) => (
         <>
           <span className="MobileSectionPanel__meetings--time">
@@ -222,7 +226,10 @@ export function MobileSectionPanel({
       </div>
       <div className="MobileSectionPanel__secondRow">
         {!section.online && (
-          <WeekdayBoxes meetingDays={getDaysOfWeekAsBooleans(section)} />
+          <WeekdayBoxes
+            meetingDays={getDaysOfWeekAsBooleans(section)}
+            meetingType={MeetingType.CLASS}
+          />
         )}
       </div>
       <div className="MobileSectionPanel__meetings">

--- a/components/ResultsPage/Results/WeekdayBoxes.tsx
+++ b/components/ResultsPage/Results/WeekdayBoxes.tsx
@@ -1,10 +1,15 @@
 import React, { ReactElement } from 'react';
+import { MeetingType } from '../../types';
 
 interface WeekdayBoxesProps {
   meetingDays: boolean[];
+  meetingType: MeetingType;
 }
 
-function WeekdayBoxes({ meetingDays }: WeekdayBoxesProps): ReactElement {
+function WeekdayBoxes({
+  meetingDays,
+  meetingType,
+}: WeekdayBoxesProps): ReactElement {
   const days = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
   return (
@@ -14,7 +19,13 @@ function WeekdayBoxes({ meetingDays }: WeekdayBoxesProps): ReactElement {
           // eslint-disable-next-line react/no-array-index-key
           <span
             key={index}
-            className={`WeekdayBoxes__box${box ? '--checked' : ''}`}
+            className={`WeekdayBoxes__box${
+              box
+                ? meetingType === MeetingType.CLASS
+                  ? '--checked-class'
+                  : '--checked-final'
+                : ''
+            }`}
           >
             {days[index]}
           </span>

--- a/components/ResultsPage/ResultsLoader.tsx
+++ b/components/ResultsPage/ResultsLoader.tsx
@@ -82,6 +82,7 @@ const getFormattedSections = (sections: any): Section[] => {
         startDate: dayjs((meeting.startDate + 1) * DAY_IN_MILLISECONDS),
         endDate: dayjs((meeting.endDate + 1) * DAY_IN_MILLISECONDS),
         times: getGroupedByTimeOfDay(meeting.times),
+        type: meeting.type,
       });
     });
 

--- a/components/types.ts
+++ b/components/types.ts
@@ -97,6 +97,12 @@ export interface Meeting {
   startDate: Dayjs;
   endDate: Dayjs;
   times: DayjsTuple[];
+  type: MeetingType;
+}
+
+export enum MeetingType {
+  CLASS = 'Class',
+  FINAL_EXAM = 'Final Exam',
 }
 
 // ======= Search Results ========

--- a/styles/results/_WeekdayBoxes.scss
+++ b/styles/results/_WeekdayBoxes.scss
@@ -17,11 +17,20 @@
     color: #979797;
     border: 0.5px solid #979797;
 
-    &--checked {
+    &--checked-class {
       display: block;
       width: 18px;
       height: 18px;
       background: #a5c0dd;
+      color: #000;
+      border: 0.5px solid #979797;
+    }
+
+    &--checked-final {
+      display: block;
+      width: 18px;
+      height: 18px;
+      background: #b0dda5;
       color: #000;
       border: 0.5px solid #979797;
     }


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.
To fix how final exams are displayed, more info on Trello.

<br>

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- [Link](https://trello.com/c/XTQqdktp/165-final-exam-is-listed-like-a-section-meeting-time-with-no-indication)

# Contributors

###### Anyone who contributed to this PR for future reference.

- Dillon Hammer
- Becca Johnson (Design)

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Final exams are now distinguishable from regular class times with a different text description + different color box.

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

Final exam info was removed from mobile, as there is no current design for mobile and I'm not sure the longer text description would fit well on the small screen.

<br>

# Checklist

- [x] Filled out PR template :wink:
- [x] Is passing linting checks
- [x] Is passing tsc
- [ ] Is passing existing tests
- [x] Has documentation and comments in code
- [ ] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu