### PR TITLE
Remove prettier from github workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,19 +3,6 @@ name: Lint
 on: pull_request
 
 jobs:
-  prettier:
-    name: prettier
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Prettify code
-        uses: creyD/prettier_action@v3.0
-        with:
-          prettier_options: --write **/*.{js,jsx,ts,tsx}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   lint:
     name: lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Purpose

Remove prettier from the GitHub workflows, since we already have a prettier pre-commit hook and the workflow prettier was formatting things differently than our pre-commit hook, resulting in unnecessary diffs.

<br>

# Tickets

None

-

# Contributors

@dillonhammer 

-

# Feature List

N/A

# Notes

N/A

<br>

# Checklist

- [x] Filled out PR template :wink:
- [x] Is passing linting checks
- [x] Is passing tsc
- [ ] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
