### PR TITLE
Ad refactor banner alerts

### DIFF
--- a/components/common/AlertBanner.tsx
+++ b/components/common/AlertBanner.tsx
@@ -3,28 +3,33 @@ import IconClose from '../icons/IconClose';
 
 type AlertLevel = 'error' | 'warning' | 'info';
 
-type AlertBannerProps = {
+export type AlertBannerData = {
+  text: string;
   alertLevel: AlertLevel;
-  alertMessage: string;
+  link?: string;
 };
 
-export default function AlertBanner({
-  alertLevel,
-  alertMessage,
-}: AlertBannerProps) {
-  const [isBannerOpen, setIsBannerOpen] = useState(true);
+type AlertBannerProps = {
+  alertBannerData: AlertBannerData;
+};
 
-  const closeBanner = () => setIsBannerOpen(false);
+export default function AlertBanner({ alertBannerData }: AlertBannerProps) {
+  const [isVisible, setIsVisible] = useState(true);
 
   return (
-    isBannerOpen && (
-      <div className={`alertBanner ${alertLevel}Banner`}>
-        {alertMessage}
+    isVisible && (
+      <div className={`alertBanner ${alertBannerData.alertLevel}Banner`}>
+        <span>
+          {alertBannerData.text}
+          {alertBannerData.link && (
+            <a href={alertBannerData.link}> Learn More.</a>
+          )}
+        </span>
         <div
           className="alertBanner__back"
           role="button"
           tabIndex={0}
-          onClick={closeBanner}
+          onClick={() => setIsVisible(false)}
         >
           <IconClose fill="#808080" />
         </div>

--- a/components/tests/pages/__snapshots__/Home.test.js.snap
+++ b/components/tests/pages/__snapshots__/Home.test.js.snap
@@ -1,38 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should render a section 1`] = `
-"<div className=\\"home-container\\">
-  <AlertBanner alertLevel=\\"error\\" alertMessage=\\"Due to a technical issue with our notification pathway through Facebook, notifications have been temporarily disabled. We\\\\'re working on a new notification flow, and apologize for any inconvenience.\\" />
-  <Head>
-    <title>
-      Search NEU - 
-      NEU
-       
-    </title>
-  </Head>
-  <a href=\\"https://www.sandboxnu.com/\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\" className=\\"sandboxLogoContainer\\">
-    <Image src=\\"/images/sandbox-logo.png\\" alt=\\"sandbox logo\\" width={47} height={61} />
-  </a>
-  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu\\" className=\\"githubCornerContainer\\">
-    <svg width=\\"80\\" height=\\"80\\" viewBox=\\"0 0 250 250\\">
-      <path d=\\"M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z\\" />
-      <path d=\\"M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2\\" fill=\\"currentColor\\" className=\\"octopusArm\\" />
-      <path d=\\"M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z\\" fill=\\"currentColor\\" />
-    </svg>
-  </a>
-  <div>
-    <div className=\\"ui center spacing aligned icon header topHeader\\">
-      <div className=\\"centerTextContainer\\">
-        <Logo className=\\"logo\\" aria-label=\\"logo\\" campus=\\"NEU\\" />
-        <HomeSearch termId=\\"202210\\" campus=\\"NEU\\" />
-        <ExploratorySearchButton termId=\\"202210\\" campus=\\"NEU\\" />
+"<div>
+  <div className=\\"alertBannerContainer\\">
+    <AlertBanner alertBannerData={{...}} />
+  </div>
+  <div className=\\"home-container\\">
+    <Head>
+      <title>
+        Search NEU - 
+        NEU
+         
+      </title>
+    </Head>
+    <a href=\\"https://www.sandboxnu.com/\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\" className=\\"sandboxLogoContainer\\">
+      <Image src=\\"/images/sandbox-logo.png\\" alt=\\"sandbox logo\\" width={47} height={61} />
+    </a>
+    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu\\" className=\\"githubCornerContainer\\">
+      <svg width=\\"80\\" height=\\"80\\" viewBox=\\"0 0 250 250\\">
+        <path d=\\"M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z\\" />
+        <path d=\\"M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2\\" fill=\\"currentColor\\" className=\\"octopusArm\\" />
+        <path d=\\"M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z\\" fill=\\"currentColor\\" />
+      </svg>
+    </a>
+    <div>
+      <div className=\\"ui center spacing aligned icon header topHeader\\">
+        <div className=\\"centerTextContainer\\">
+          <Logo className=\\"logo\\" aria-label=\\"logo\\" campus=\\"NEU\\" />
+          <HomeSearch termId=\\"202210\\" campus=\\"NEU\\" />
+          <ExploratorySearchButton termId=\\"202210\\" campus=\\"NEU\\" />
+        </div>
+        <Husky className=\\"husky\\" campus=\\"NEU\\" aria-label=\\"husky\\" />
+        <div className=\\"bostonContainer\\">
+          <SvgBoston className=\\"boston\\" aria-label=\\"logo\\" />
+        </div>
       </div>
-      <Husky className=\\"husky\\" campus=\\"NEU\\" aria-label=\\"husky\\" />
-      <div className=\\"bostonContainer\\">
-        <SvgBoston className=\\"boston\\" aria-label=\\"logo\\" />
-      </div>
+      <Memo(Footer) />
     </div>
-    <Memo(Footer) />
   </div>
 </div>"
 `;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,3 +2,8 @@ declare module '*.svg' {
   const ReactComponent: React.FC<React.SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
+
+declare module '*.yml' {
+  const data: any;
+  export default data;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
   transform: {
     '^.+\\.(js|jsx|ts|tsx)$': '<rootDir>/node_modules/babel-jest',
     '^.+\\.svg$': 'jest-svg-transformer',
+    '^.+\\.yml$': '<rootDir>/node_modules/yaml-jest',
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,11 @@ module.exports = withPlugins(
         use: ['@svgr/webpack'],
       });
 
+      config.module.rules.push({
+        test: /\.ya?ml$/,
+        use: 'js-yaml-loader',
+      });
+
       return config;
     },
     async redirects() {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "interweave": "^12.6.0",
     "is-mobile": "^2.2.2",
     "jest-svg-transformer": "^1.0.0",
+    "js-yaml-loader": "^1.2.2",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",
     "mock-local-storage": "^1.1.15",
@@ -59,7 +60,8 @@
     "swr": "^0.3.11",
     "use-deep-compare-effect": "^1.6.1",
     "use-query-params": "^1.1.9",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "yaml-jest": "^1.0.5"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "1.20.0",

--- a/pages/[campus]/[termId].tsx
+++ b/pages/[campus]/[termId].tsx
@@ -15,8 +15,11 @@ import Boston from '../../components/icons/boston.svg';
 import Husky from '../../components/icons/Husky';
 import Logo from '../../components/icons/Logo';
 import macros from '../../components/macros';
-import AlertBanner from '../../components/common/AlertBanner';
+import AlertBanner, {
+  AlertBannerData,
+} from '../../components/common/AlertBanner';
 import { Campus } from '../../components/types';
+import alertBannersData from '../../public/alert-banners.yml';
 
 export default function Home(): ReactElement {
   const router = useRouter();
@@ -28,6 +31,8 @@ export default function Home(): ReactElement {
   const AVAILABLE_TERM_IDS = getTermInfoForCampus(campus).map((t) => {
     return t.value;
   });
+
+  const alertBanners = Object.values(alertBannersData) as [AlertBannerData];
 
   // Redirect to latest if we're at an old term
   if (!AVAILABLE_TERM_IDS.includes(termId)) {
@@ -42,63 +47,66 @@ export default function Home(): ReactElement {
   }
 
   return (
-    <div className={containerClassnames}>
-      {/*TODO: remove when notification is fixed */}
-      <AlertBanner
-        alertLevel="error"
-        alertMessage="Due to a technical issue with our notification pathway through Facebook, notifications have been temporarily disabled. We're working on a new notification flow, and apologize for any inconvenience."
-      />
-      <Head>
-        <title>Search NEU - {campus} </title>
-      </Head>
-      <a
-        href="https://www.sandboxnu.com/"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="sandboxLogoContainer"
-      >
-        <Image
-          src="/images/sandbox-logo.png"
-          alt="sandbox logo"
-          width={47}
-          height={61}
-        />
-      </a>
-      <a
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://github.com/sandboxnu/searchneu"
-        className="githubCornerContainer"
-      >
-        <svg width="80" height="80" viewBox="0 0 250 250">
-          <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z" />
-          <path
-            d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
-            fill="currentColor"
-            className="octopusArm"
-          />
-          <path
-            d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
-            fill="currentColor"
-          />
-        </svg>
-      </a>
-
-      <div>
-        <div // TODO: Take this out and restyle this monstrosity from scratch
-          className="ui center spacing aligned icon header topHeader"
+    <div>
+      <div className="alertBannerContainer">
+        {alertBanners.map((alertBanner) => (
+          <AlertBanner key={alertBanner.text} alertBannerData={alertBanner} />
+        ))}
+      </div>
+      <div className={containerClassnames}>
+        {/*TODO: remove when notification is fixed */}
+        <Head>
+          <title>Search NEU - {campus} </title>
+        </Head>
+        <a
+          href="https://www.sandboxnu.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="sandboxLogoContainer"
         >
-          <div className="centerTextContainer">
-            <Logo className="logo" aria-label="logo" campus={campus} />
-            <HomeSearch termId={termId} campus={campus} />
-            <ExploratorySearchButton termId={termId} campus={campus} />
+          <Image
+            src="/images/sandbox-logo.png"
+            alt="sandbox logo"
+            width={47}
+            height={61}
+          />
+        </a>
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://github.com/sandboxnu/searchneu"
+          className="githubCornerContainer"
+        >
+          <svg width="80" height="80" viewBox="0 0 250 250">
+            <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z" />
+            <path
+              d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+              fill="currentColor"
+              className="octopusArm"
+            />
+            <path
+              d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+              fill="currentColor"
+            />
+          </svg>
+        </a>
+
+        <div>
+          <div // TODO: Take this out and restyle this monstrosity from scratch
+            className="ui center spacing aligned icon header topHeader"
+          >
+            <div className="centerTextContainer">
+              <Logo className="logo" aria-label="logo" campus={campus} />
+              <HomeSearch termId={termId} campus={campus} />
+              <ExploratorySearchButton termId={termId} campus={campus} />
+            </div>
+            <Husky className="husky" campus={campus} aria-label="husky" />
+            <div className="bostonContainer">
+              <Boston className="boston" aria-label="logo" />
+            </div>
           </div>
-          <Husky className="husky" campus={campus} aria-label="husky" />
-          <div className="bostonContainer">
-            <Boston className="boston" aria-label="logo" />
-          </div>
+          <Footer />
         </div>
-        <Footer />
       </div>
     </div>
   );

--- a/public/alert-banners.yml
+++ b/public/alert-banners.yml
@@ -1,0 +1,12 @@
+# This file is used to render banner alerts on the front page of search
+# To add an alert, add a new entry at the top level, preferrably with a descriptive name for the alert
+# Then, add key-value pair entries to that object, text, alertLevel, isVisible, and optional link. Example:
+# notificationsAlert:
+#   text: "Due to a technical issue with our notification pathway through Facebook, notifications have been temporarily disabled. We're working on a new notification flow, and apologize for any inconvenience."
+#   alertLevel: "error"
+#   link: "https://www.w3schools.com"
+# For more info, check out the AlertBanner.tsx file
+---
+notificationsAlert:
+  text: 'Due to a technical issue, Facebook notifications have been temporarily disabled.'
+  alertLevel: 'error'

--- a/styles/_AlertBanner.scss
+++ b/styles/_AlertBanner.scss
@@ -1,19 +1,20 @@
-.alertBanner {
+.alertBannerContainer {
   z-index: 100000;
-  position: fixed;
-  bottom: 0px;
+  top: 0px;
   width: 100%;
+}
+
+.alertBanner {
   filter: drop-shadow(3px 1px 4px grey);
   padding: 15px 15px 15px 15px;
+  text-align: center;
   font-size: 15px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 
   &__back {
     height: 15px;
     width: 15px;
     float: right;
+    margin-right: 30px;
   }
 
   &__back:hover {

--- a/styles/pages/_Home.scss
+++ b/styles/pages/_Home.scss
@@ -7,6 +7,7 @@
 
 .home-container {
   height: 100%;
+  position: relative;
 
   .displayNone {
     display: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6738,7 +6738,16 @@ jquery@x.*:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^3.14.0:
+js-yaml-loader@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/js-yaml-loader/-/js-yaml-loader-1.2.2.tgz#2c15f93915617acd19676d648945fa3003f8629b"
+  integrity sha512-H+NeuNrG6uOs/WMjna2SjkaCw13rMWiT/D7l9+9x5n8aq88BDsh2sRmdfxckWPIHtViYHWRG6XiCKYvS1dfyLg==
+  dependencies:
+    js-yaml "^3.13.1"
+    loader-utils "^1.2.3"
+    un-eval "^1.2.0"
+
+js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.7.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -10597,6 +10606,11 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.23.tgz#704d67f951e13195fbcd3d78818577f5bc1d547b"
   integrity sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==
 
+un-eval@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/un-eval/-/un-eval-1.2.0.tgz#22a95c650334d59d21697efae32612218ecad65f"
+  integrity sha512-Wlj/pum6dQtGTPD/lclDtoVPkSfpjPfy1dwnnKw/sZP5DpBH9fLhBgQfsqNhe5/gS1D+vkZUuB771NRMUPA5CA==
+
 unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -11167,6 +11181,13 @@ yaml-ast-parser@^0.0.43:
   version "0.0.43"
   resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
   integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
+
+yaml-jest@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/yaml-jest/-/yaml-jest-1.0.5.tgz#288e541bae1b551d113d4864d6cb8f316e1bd331"
+  integrity sha1-KI5UG64bVR0RPUhk1suPMW4b0zE=
+  dependencies:
+    js-yaml "^3.7.0"
 
 yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.0"


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.
This pr refactors the AlertBanner component to draw data from a yaml file in the public folder. This is to reduce the need to do inline code changes to add banners. Going forward, front page alert banners can be added by modifying the `alert-banners.yml` file.

<br>

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- My bad, no ticket :( 

# Contributors

###### Anyone who contributed to this PR for future reference.

- Andrew Dai

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Adds the ability to load and use yaml files throughout the project
- Adds a yaml file for easier adding and changing of banners in the future
- alert-banners.yml supports modifying alert level, text, visibility, and links for alerts
- Can easily render multiple alerts now

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

<br>

# Checklist

- [x] Filled out PR template :wink:
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
