### PR TITLE
Adjusts styles for classes and finals that are checked

### DIFF
--- a/styles/results/_WeekdayBoxes.scss
+++ b/styles/results/_WeekdayBoxes.scss
@@ -41,7 +41,11 @@
     border-right: none;
   }
 
-  &__box--checked:nth-child(even) {
+  &__box--checked-class:nth-child(even) {
+    border-left: none;
+    border-right: none;
+  }
+  &__box--checked-final:nth-child(even) {
     border-left: none;
     border-right: none;
   }


### PR DESCRIPTION
# Purpose

This PR fixes a minor bug/design nit that occurred when we added separate colors for classes/finals in the weekday checkboxes, where double borders occurred on some active boxes (M,W,F). 

<br>

# Tickets

https://trello.com/c/IAeTuZDL


# Contributors

- Rebekah Johnson

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.


# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

<br>

# Checklist

- [x] Filled out PR template :wink:
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
