### PR TITLE
Attempt To Fix _next/static js file not loading in prod

### DIFF
--- a/components/ClassPage/ClassPageReqsBody.tsx
+++ b/components/ClassPage/ClassPageReqsBody.tsx
@@ -86,9 +86,9 @@ export default function ClassPageReqsBody({
           header="LINK"
           className="link"
           body={
-            <Link href={latestOccurrence.prettyUrl}>
+            <a href={latestOccurrence.prettyUrl}>
               Click here to view this course on the Northeastern website.
-            </Link>
+            </a>
           }
         />
         <HeaderBody


### PR DESCRIPTION
# Purpose

In the production environment only, frontend does not work because some js files aren't being found and loaded.

<br>

# Tickets

###### A link to any tickets this PR is associated with on Trello.

-

# Contributors

@megandouli 

-

# Notes

- Might have something to do with Next.js <Link> components getting prefetched in production only. Apparently <Link> components should only be used for Next.js created pages?

<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [ ] Is passing tsc
- [x] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
