### PR TITLE
add hard-coded termids for undergrad,cps, and law

### DIFF
--- a/components/global.ts
+++ b/components/global.ts
@@ -10,6 +10,7 @@ interface TermInfo {
 }
 
 export const neuTerms: TermInfo[] = [
+  { text: 'Spring 2022', value: '202230' },
   { text: 'Fall 2021', value: '202210' },
   { text: 'Summer II 2021', value: '202160' },
   { text: 'Summer Full 2021', value: '202150' },
@@ -22,6 +23,11 @@ export const neuTerms: TermInfo[] = [
 ].map((o) => ({ ...o, href: `/NEU/${o.value}` }));
 // spring 2021 CPS semester
 export const cpsTerms: TermInfo[] = [
+  { text: 'Spring 2022 Semester', value: '202234' },
+  { text: 'Spring 2022 Quarter', value: '202235' },
+  { text: 'Winter 2022 Quarter', value: '202225' },
+  { text: 'Fall 2022 Semester', value: '202214' },
+  { text: 'Fall 2022 Quarter', value: '202215' },
   { text: 'Summer 2021 Semester', value: '202154' },
   { text: 'Summer 2021 Quarter', value: '202155' },
   { text: 'Spring 2021 Semester ', value: '202134' },
@@ -34,6 +40,11 @@ export const cpsTerms: TermInfo[] = [
 ].map((o) => ({ ...o, href: `/CPS/${o.value}` }));
 
 export const lawTerms: TermInfo[] = [
+  { text: 'Spring 2022 Semester', value: '202232' },
+  { text: 'Spring 2022 Quarter', value: '202238' },
+  { text: 'Winter 2022 Quarter', value: '202228' },
+  { text: 'Fall 2022 Semester', value: '202212' },
+  { text: 'Fall 2022 Quarter', value: '202218' },
   { text: 'Summer 2021 Semester', value: '202152' },
   { text: 'Summer 2021 Quarter', value: '202158' },
   { text: 'Spring 2021 Semester', value: '202132' },

--- a/components/tests/pages/__snapshots__/Home.test.js.snap
+++ b/components/tests/pages/__snapshots__/Home.test.js.snap
@@ -27,8 +27,8 @@ exports[`should render a section 1`] = `
       <div className=\\"ui center spacing aligned icon header topHeader\\">
         <div className=\\"centerTextContainer\\">
           <Logo className=\\"logo\\" aria-label=\\"logo\\" campus=\\"NEU\\" />
-          <HomeSearch termId=\\"202210\\" campus=\\"NEU\\" />
-          <ExploratorySearchButton termId=\\"202210\\" campus=\\"NEU\\" />
+          <HomeSearch termId=\\"202230\\" campus=\\"NEU\\" />
+          <ExploratorySearchButton termId=\\"202230\\" campus=\\"NEU\\" />
         </div>
         <Husky className=\\"husky\\" campus=\\"NEU\\" aria-label=\\"husky\\" />
         <div className=\\"bostonContainer\\">

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -105,6 +105,15 @@ exports[`should render a section 1`] = `
                             </Icon>
                             <DropdownMenu className=\\"\\">
                               <div className=\\"menu transition\\">
+                                <Link href=\\"/NEU/202230/search/cs\\">
+                                  <DropdownItem selected={false} text=\\"Spring 2022\\" onClick={[Function: onClick]} onMouseEnter={[Function (anonymous)]}>
+                                    <div onMouseEnter={[Function (anonymous)]} role=\\"option\\" aria-disabled={[undefined]} aria-checked={[undefined]} aria-selected={false} className=\\"item\\" onClick={[Function (anonymous)]}>
+                                      <span className=\\"text\\">
+                                        Spring 2022
+                                      </span>
+                                    </div>
+                                  </DropdownItem>
+                                </Link>
                                 <Link href=\\"/NEU/202210/search/cs\\">
                                   <DropdownItem selected={false} text=\\"Fall 2021\\" onClick={[Function: onClick]} onMouseEnter={[Function (anonymous)]}>
                                     <div onMouseEnter={[Function (anonymous)]} role=\\"option\\" aria-disabled={[undefined]} aria-checked={[undefined]} aria-selected={false} className=\\"item\\" onClick={[Function (anonymous)]}>


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.
This pr adds hardcoded term id's for the cps, law, and undergrad classes that get released soon. These include Fall, Winter, and Spring for CPS and LAW, and Spring for undergrad.

<br>\

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- https://trello.com/c/fB4DgHRC/255-get-most-recent-law-cps-terms-up

# Contributors

###### Anyone who contributed to this PR for future reference.

- Andrew Dai

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Hardcoded term id's in global.ts
-
-

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.
N/A
<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
