### PR TITLE
Changed termId types to be String instead of Int

### DIFF
--- a/components/ResultsPage/useSearch.ts
+++ b/components/ResultsPage/useSearch.ts
@@ -82,7 +82,7 @@ export default function useSearch({
     async (params): Promise<SearchResult> => {
       params = JSON.parse(params);
       const searchResults = await gqlClient.searchResults({
-        termId: parseInt(termId),
+        termId,
         query: params.query,
         offset: parseInt(params.minIndex),
         ...params.filters,

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -48,7 +48,7 @@ export type ClassOccurrence = {
   name: Scalars['String'];
   subject: Scalars['String'];
   classId: Scalars['String'];
-  termId: Scalars['Int'];
+  termId: Scalars['String'];
   desc: Scalars['String'];
   prereqs?: Maybe<Scalars['JSON']>;
   coreqs?: Maybe<Scalars['JSON']>;
@@ -159,7 +159,7 @@ export type QueryMajorArgs = {
 };
 
 export type QuerySearchArgs = {
-  termId: Scalars['Int'];
+  termId: Scalars['String'];
   query?: Maybe<Scalars['String']>;
   subject?: Maybe<Array<Scalars['String']>>;
   nupath?: Maybe<Array<Scalars['String']>>;
@@ -270,7 +270,7 @@ export type GetClassPageInfoQuery = { __typename?: 'Query' } & {
 };
 
 export type SearchResultsQueryVariables = Exact<{
-  termId: Scalars['Int'];
+  termId: Scalars['String'];
   query?: Maybe<Scalars['String']>;
   offset?: Maybe<Scalars['Int']>;
   first?: Maybe<Scalars['Int']>;
@@ -403,7 +403,7 @@ export type GetSectionInfoByHashQuery = { __typename?: 'Query' } & {
 };
 
 export type GetPagesForSitemapQueryVariables = Exact<{
-  termId: Scalars['Int'];
+  termId: Scalars['String'];
   offset: Scalars['Int'];
 }>;
 
@@ -477,7 +477,7 @@ export const GetClassPageInfoDocument = gql`
 `;
 export const SearchResultsDocument = gql`
   query searchResults(
-    $termId: Int!
+    $termId: String!
     $query: String
     $offset: Int = 0
     $first: Int = 10
@@ -594,7 +594,7 @@ export const GetSectionInfoByHashDocument = gql`
   }
 `;
 export const GetPagesForSitemapDocument = gql`
-  query getPagesForSitemap($termId: Int!, $offset: Int!) {
+  query getPagesForSitemap($termId: String!, $offset: Int!) {
     search(termId: $termId, offset: $offset, first: 1000) {
       pageInfo {
         hasNextPage

--- a/pages/api/searchResult.graphql
+++ b/pages/api/searchResult.graphql
@@ -1,5 +1,5 @@
 query searchResults(
-  $termId: Int!
+  $termId: String!
   $query: String
   $offset: Int = 0
   $first: Int = 10

--- a/pages/api/sitemap.graphql
+++ b/pages/api/sitemap.graphql
@@ -1,4 +1,4 @@
-query getPagesForSitemap($termId: Int!, $offset: Int!) {
+query getPagesForSitemap($termId: String!, $offset: Int!) {
   search(termId: $termId, offset: $offset, first: 1000) {
     pageInfo {
       hasNextPage

--- a/pages/api/sitemap.xml.ts
+++ b/pages/api/sitemap.xml.ts
@@ -6,7 +6,7 @@ import { gqlClient } from '../../utils/courseAPIClient';
 
 // Execute the proc on each search result in the given termId
 async function forEachSearchResult(
-  termId: number,
+  termId: string,
   proc: (item: GetPagesForSitemapQuery['search']['nodes'][0]) => void
 ) {
   let offset = 0;
@@ -30,9 +30,9 @@ async function generateSitemap(): Promise<string> {
   const items: Set<string> = new Set();
 
   // latest terms for each campus
-  const latestTerms: [Campus, number][] = Object.values(Campus).map((c) => [
+  const latestTerms: [Campus, string][] = Object.values(Campus).map((c) => [
     c,
-    Number(getLatestTerm(c)),
+    getLatestTerm(c),
   ]);
 
   // Add the classes
@@ -53,7 +53,7 @@ async function generateSitemap(): Promise<string> {
   }
 
   // Add the employees
-  const latestNEU = Number(getLatestTerm(Campus.NEU));
+  const latestNEU = getLatestTerm(Campus.NEU);
   await forEachSearchResult(latestNEU, (employee) => {
     if (employee.__typename === 'Employee') {
       items.add(


### PR DESCRIPTION
# Purpose

Keeps termId type definition consistent as a String.

<br>

# Tickets

https://trello.com/c/nhlGeXYn/245-consistent-graphql-type-for-termid


# Contributors

- Simar Chadha
- Megan Li


# Feature List

termId was defined as an int in some places and as a string in other places. Made front end changes that keep termId as a string consistently. 



<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [ ] Is passing linting checks
- [ ] Is passing tsc
- [ ] Is passing existing tests
- [x] Has documentation and comments in code
- [ ] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
