### PR TITLE
Class Pages Hot Fix

### DIFF
--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -259,7 +259,6 @@ export type GetClassPageInfoQuery = { __typename?: 'Query' } & {
                     | 'campus'
                     | 'profs'
                     | 'meetings'
-                    | 'lastUpdateTime'
                   >
                 >;
               }
@@ -469,7 +468,6 @@ export const GetClassPageInfoDocument = gql`
           campus
           profs
           meetings
-          lastUpdateTime
         }
       }
     }

--- a/pages/api/classPage.graphql
+++ b/pages/api/classPage.graphql
@@ -32,7 +32,6 @@ query getClassPageInfo($subject: String!, $classId: String!) {
         campus
         profs
         meetings
-        lastUpdateTime
       }
     }
   }


### PR DESCRIPTION
# Purpose

Class pages broke in prod after Andrew and Megan fiddled around with `last_update_time` for sections. We set that column to the current timestamp for old sections. It appears GraphQL expects that value to be a float and ran into problems serializing. 

The fix for now is to remove `lastUpdateTime` from the sections field of the GraphQL query for class pages. This field wasn't being used anywhere to render the class page.

<br>

# Tickets

###### A link to any tickets this PR is associated with on Trello.

-

# Contributors

###### Anyone who contributed to this PR for future reference.

-

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

-
-
-

# Notes

TODO: fix bug with `last_update_time` in prod

<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [ ] Is passing linting checks
- [ ] Is passing tsc
- [ ] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
