### PR TITLE
Fix getRoundedTerm logic error

### DIFF
--- a/components/terms.ts
+++ b/components/terms.ts
@@ -86,23 +86,23 @@ export function getRoundedTerm(
   nextCampus: Campus,
   prevTerm: string
 ): string {
-  const prevterm_int = Number(prevTerm);
+  const prevTermInt = Number(prevTerm);
 
   const closestTerm = termInfos[nextCampus].reduce(
     (prev, current: TermInfo) => {
-      const curterm_int = Number(current.value);
-      const diff = Math.abs(prevterm_int - curterm_int);
+      const curTermInt = Number(current.value);
+      const diff = Math.abs(prevTermInt - curTermInt);
       // Returns the term which is closest to the previous term
-      if (diff < prev['diff']) {
-        return { term_str: current.value, term_int: curterm_int, diff: diff };
+      if (diff < prev.diff) {
+        return { termStr: current.value, diff: diff };
       }
       return prev;
       // Initial value (which will always be replaced)
     },
-    { term_str: '', term_int: '', diff: Number.MAX_SAFE_INTEGER }
+    { termStr: '', diff: Number.MAX_SAFE_INTEGER }
   );
 
-  return closestTerm['term_str'];
+  return closestTerm.termStr;
 }
 
 // Get the name version of a term id

--- a/components/terms.ts
+++ b/components/terms.ts
@@ -80,49 +80,29 @@ export function greaterTermExists(
   });
 }
 
-function getSecondToLastDigit(s: string): string {
-  return s.charAt(s.length - 2);
-}
-
-function tryGetMatchingSecondToLastDigitOption(
-  secondToLast: string,
-  options: TermInfo[]
-): TermInfo | undefined {
-  for (const option of options) {
-    const secondToLastOfOption = getSecondToLastDigit(option.value as string);
-    if (secondToLast === secondToLastOfOption) {
-      return option;
-    }
-  }
-
-  return undefined;
-}
-
 /** Get the term within the given campus that is closest to the given term (in a diff campus) */
 export function getRoundedTerm(
   termInfos: Record<Campus, TermInfo[]>,
   nextCampus: Campus,
   prevTerm: string
 ): string {
-  // get the second to last digit
-  const secondToLast = getSecondToLastDigit(prevTerm);
+  const prevterm_int = Number(prevTerm);
 
-  // search in there for the value where the second to last digit
-  const result = tryGetMatchingSecondToLastDigitOption(
-    secondToLast,
-    termInfos[nextCampus]
+  const closestTerm = termInfos[nextCampus].reduce(
+    (prev, current: TermInfo) => {
+      const curterm_int = Number(current.value);
+      const diff = Math.abs(prevterm_int - curterm_int);
+      // Returns the term which is closest to the previous term
+      if (diff < prev['diff']) {
+        return { term_str: current.value, term_int: curterm_int, diff: diff };
+      }
+      return prev;
+      // Initial value (which will always be replaced)
+    },
+    { term_str: '', term_int: '', diff: Number.MAX_SAFE_INTEGER }
   );
 
-  if (result) {
-    return result.value as string;
-  }
-  // here, there was no result with the corresponding digit. so round down and try again.
-  const roundedDownDigit = String(Number(secondToLast) - 1);
-  const result2 = tryGetMatchingSecondToLastDigitOption(
-    roundedDownDigit,
-    termInfos[nextCampus]
-  );
-  return result2 ? (result2.value as string) : '';
+  return closestTerm['term_str'];
 }
 
 // Get the name version of a term id
@@ -147,7 +127,7 @@ export function getTermName(
 }
 
 export function getSeason(termId: string): string {
-  const seasonDigit = getSecondToLastDigit(termId);
+  const seasonDigit = termId.charAt(termId.length - 2);
   const seasonDigitMap = {
     '1': 'Fall',
     '2': 'Winter',


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

getRoundedTerm (in the frontend, in global.ts) tried to get the term within the given campus that is closest to the given term (in a diff campus)

It does this by checking the semester code (not the year), and matching. 

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- https://trello.com/c/gwdj0Z8n/259-getroundedterm-logic-error

# Contributors

###### Anyone who contributed to this PR for future reference.

- Zachar Hankewycz

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Changed function to take the closest term, as measured by the abs difference of the previous term and the given term
- 
# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

N/A

# Checklist

- [x] Filled out PR template :wink:
- [x] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
