### PR TITLE
Add tooltips back to class pages

### DIFF
--- a/components/ClassPage/ClassPageSections.tsx
+++ b/components/ClassPage/ClassPageSections.tsx
@@ -135,7 +135,7 @@ function SectionCard({ section }: SectionCardProps): ReactElement {
         </a>
         <Tooltip
           text={'View this section on Banner.'}
-          direction={TooltipDirection.Up}
+          direction={TooltipDirection.Down}
         />
       </div>
       {classMeetings.map((meeting, index) => {

--- a/components/ClassPage/ClassPageSections.tsx
+++ b/components/ClassPage/ClassPageSections.tsx
@@ -2,13 +2,14 @@ import dayjs from 'dayjs';
 import { chunk, partition, sortBy, uniq, uniqWith } from 'lodash';
 import React, { ReactElement, useEffect, useState } from 'react';
 import { Dropdown } from 'semantic-ui-react';
-import { GetClassPageInfoQuery, Section } from '../../generated/graphql';
+import { GetClassPageInfoQuery } from '../../generated/graphql';
 import IconGlobe from '../icons/IconGlobe';
 import useSectionPanelDetail from '../ResultsPage/Results/useSectionPanelDetail';
 import WeekdayBoxes from '../ResultsPage/Results/WeekdayBoxes';
 import { getGroupedByTimeOfDay } from '../ResultsPage/ResultsLoader';
-import { MeetingType, Meeting } from '../types';
+import { MeetingType } from '../types';
 import SectionsTermNav from './SectionsTermNav';
+import Tooltip, { TooltipDirection } from '../Tooltip';
 
 type ClassPageSectionsProps = {
   classPageInfo: GetClassPageInfoQuery;
@@ -129,7 +130,13 @@ function SectionCard({ section }: SectionCardProps): ReactElement {
     <div className="sectionCard">
       <div className="sectionCardProfs">{section.profs.join(', ')}</div>
       <div className="sectionCRN">
-        <IconGlobe /> {section.crn}
+        <a href={section.url} target="_blank" rel="noopener noreferrer">
+          <IconGlobe /> {section.crn}
+        </a>
+        <Tooltip
+          text={'View this section on Banner.'}
+          direction={TooltipDirection.Up}
+        />
       </div>
       {classMeetings.map((meeting, index) => {
         return (

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -271,6 +271,7 @@ export type GetClassPageInfoQuery = { __typename?: 'Query' } & {
                     | 'campus'
                     | 'profs'
                     | 'meetings'
+                    | 'url'
                   >
                 >;
               }
@@ -490,6 +491,7 @@ export const GetClassPageInfoDocument = gql`
           campus
           profs
           meetings
+          url
         }
       }
     }

--- a/pages/api/classPage.graphql
+++ b/pages/api/classPage.graphql
@@ -32,6 +32,7 @@ query getClassPageInfo($subject: String!, $classId: String!) {
         campus
         profs
         meetings
+        url
       }
     }
   }

--- a/styles/pages/_ClassPage.scss
+++ b/styles/pages/_ClassPage.scss
@@ -100,9 +100,7 @@
       background: #338ef1;
       white-space: nowrap;
       & > div {
-        border-color: #338ef1 transparent transparent transparent;
-        right: 29px;
-        top: 24px;
+        border-color: transparent transparent #338ef1 transparent;
       }
     }
   }

--- a/styles/pages/_ClassPage.scss
+++ b/styles/pages/_ClassPage.scss
@@ -81,6 +81,32 @@
     align-items: center;
   }
 
+  .classPageLastUpdated > a {
+    &:hover + .tooltip {
+      display: block;
+      margin-top: 70px;
+      margin-left: -5px;
+      background: #505050;
+      & > div {
+        border-color: transparent transparent #505050 transparent;
+        left: 12px;
+      }
+    }
+  }
+
+  .sectionCRN > a {
+    &:hover + .tooltip {
+      display: block;
+      background: #338ef1;
+      white-space: nowrap;
+      & > div {
+        border-color: #338ef1 transparent transparent transparent;
+        right: 29px;
+        top: 24px;
+      }
+    }
+  }
+
   .creditsDisplay {
     text-align: center;
 


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

For consistency, tooltips/CRN links should be consistent on both search results and class pages. Currently these are not up and running on class pages.

# Tickets

###### A link to any tickets this PR is associated with on Trello.

-https://trello.com/c/HZbRtK2z/242-tooltips-crn-links-not-active-on-class-pages

# Contributors

###### Anyone who contributed to this PR for future reference.

- Zachar

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Added tooltips to main class URL on class pages (just required a CSS change)
- Add URL to sections graphql query (to support links)
- Added tooltip to sections CRNs

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [ ] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
