### PR TITLE
Fixed <br/> rendering inconsistency on desktop and master

### DIFF
--- a/components/ResultsPage/Results/SearchResult.tsx
+++ b/components/ResultsPage/Results/SearchResult.tsx
@@ -247,7 +247,7 @@ export function MobileSearchResult({
                   : 'MobileSearchResult__panel--descriptionHidden'
               }
             >
-              {course.desc}
+              <Markup content={course.desc} />
             </div>
             <div
               className="MobileSearchResult__panel--showMore"


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br>
There's an html element in the course description of CS4810. On desktop, it shows as a random line break. On mobile, it shows as `&lt;br/&gt;`

# Tickets

###### A link to any tickets this PR is associated with on Trello.

-https://trello.com/c/2pirfVyp/236-br-frontend-bug

# Contributors

###### Anyone who contributed to this PR for future reference.

- Zachar

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

-Wraps the mobile search result with a Markup element (which already existed for desktop) which safely renders some HTML formatting tags

Before: https://i.imgur.com/AhrPMVv.png
After: https://i.imgur.com/F41Y1IL.png


The class in question: https://searchneu.com/NEU/202110/search/cs4810

(Can be replicated on desktop, using a responsive window size)

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
