### PR TITLE
Fix prereq parentheses

### DIFF
--- a/components/ResultsPage/Results/useResultDetail.tsx
+++ b/components/ResultsPage/Results/useResultDetail.tsx
@@ -139,14 +139,19 @@ export default function useResultDetail(
 
         retVal.push(element);
       } else if (reqType === PrereqType.PREREQ && isCompositeReq(childBranch)) {
-        // Figure out how many unique classIds there are in the prereqs.
-        const allClassIds = {};
+        // Figure out how many unique elements there are in the prereqs.
+        const uniqueElements: Set<string> = new Set();
+
         for (const node of childBranch.values) {
-          if (isCourseReq(node)) allClassIds[node.classId] = true;
+          if (isCourseReq(node)) {
+            uniqueElements.add(`${node.subject}${node.classId}`);
+          } else if (typeof node === 'string') {
+            uniqueElements.add(node);
+          }
         }
 
         // If there is only 1 prereq with a unique classId, don't show the parens.
-        if (Object.keys(allClassIds).length === 1) {
+        if (uniqueElements.size === 1) {
           retVal.push(
             getReqsStringHelper(
               childBranch,


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br>

Parentheses aren't correct for the prereqs for PHMD 5223: Evidence-Based Medicine in Spring 2022. What's rendered is ENGW 3306 or Graduate Admission and (PHMD 3450 or NRSG 5120 or PHTH 4202 or HLTH 5450) but there should be parentheses around (ENGW 3306 or Graduate Admission). 

This fixes the lack of parentheses for non-course requisites


# Tickets

###### A link to any tickets this PR is associated with on Trello.

- https://trello.com/c/0ZgdFDJK/275-prereq-parentheses

# Contributors

###### Anyone who contributed to this PR for future reference.

- Zachar

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Take non-course requisites into consideration when deciding whether to enclose in parentheses or not

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.
Before:
![image](https://user-images.githubusercontent.com/27775244/144665159-2fe3498b-c29c-449d-9fac-4b6aa02b9900.png)


After:
![image](https://user-images.githubusercontent.com/27775244/144665129-4269b6dd-ed5b-4b6f-b0e6-0723e29cfd46.png)


<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
