### PR TITLE
Fix 'undefined undefined' for course page prereqs

### DIFF
--- a/components/ClassPage/PrereqsDisplay.tsx
+++ b/components/ClassPage/PrereqsDisplay.tsx
@@ -1,7 +1,10 @@
 import Link from 'next/link';
 import React, { ReactElement } from 'react';
-import { isCompositeReq } from '../ResultsPage/Results/useResultDetail';
-import { CompositeReq, CourseReq, Requisite } from '../types';
+import {
+  isCompositeReq,
+  isCourseReq,
+} from '../ResultsPage/Results/useResultDetail';
+import { CompositeReq, Requisite } from '../types';
 
 type PrereqsDisplayProps = {
   termId: string;
@@ -70,13 +73,18 @@ export default function PrereqsDisplay({
         </>
       );
     }
-  } else {
-    const prereq: CourseReq = prereqs as CourseReq;
+  } else if (isCourseReq(prereqs)) {
     return (
-      <li key={prereq.subject + prereq.classId}>
+      <li key={prereqs.subject + prereqs.classId}>
         <Link
-          href={`/${campus}/${termId}/classPage/${prereq.subject}/${prereq.classId}`}
-        >{`${prereq.subject} ${prereq.classId}`}</Link>
+          href={`/${campus}/${termId}/classPage/${prereqs.subject}/${prereqs.classId}`}
+        >{`${prereqs.subject} ${prereqs.classId}`}</Link>
+      </li>
+    );
+  } else {
+    return (
+      <li key={prereqs}>
+        <span>{prereqs}</span>
       </li>
     );
   }


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br>

 On class pages, text-based (as opposed to courses) prereqs show up as undefined undefined. This is not an issue with search results.


# Tickets

###### A link to any tickets this PR is associated with on Trello.

-https://trello.com/c/4O0h9Cih/280-graduation-admission-dissertation-check-show-up-as-undefined-undefined-on-class-pages

# Contributors

###### Anyone who contributed to this PR for future reference.

-Zachar

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

<br>

Before:
![image](https://user-images.githubusercontent.com/27775244/144666565-f77ae08c-5eba-4fb9-b41a-3b6c903e88e6.png)


After:
![image](https://user-images.githubusercontent.com/27775244/144666589-cfa9d86d-8677-466c-a17c-c439ceda4368.png)


# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [ ] Is passing linting checks
- [ ] Is passing tsc
- [ ] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
