### PR TITLE
Added an honors tag to desktop and mobile view

### DIFF
--- a/components/ResultsPage/Results/SectionPanel.tsx
+++ b/components/ResultsPage/Results/SectionPanel.tsx
@@ -154,6 +154,14 @@ export function DesktopSectionPanel({
           text={'View this section on Banner.'}
           direction={TooltipDirection.Up}
         />
+        {section.honors ? (
+          <i>
+            <br />
+            Honors
+          </i>
+        ) : (
+          ''
+        )}
       </td>
       <td>{getProfs(section).join(', ')}</td>
       <td>
@@ -239,7 +247,10 @@ export function MobileSectionPanel({
           <a target="_blank" rel="noopener noreferrer" href={section.url}>
             <IconGlobe />
           </a>
-          <span>{section.crn}</span>
+          <span>
+            {section.crn}
+            {section.honors ? <i>&nbsp;&nbsp;&nbsp;Honors</i> : ''}
+          </span>
         </div>
         {showNotificationSwitches && (
           <SectionCheckBox


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br>Bug: According to the spec, if a section is Accelerated or Honors (or otherwise "special", it should be noted under the CRN of that section) see link under CRN in sections:

# Tickets

###### A link to any tickets this PR is associated with on Trello.

-https://trello.com/c/qXh3IKKO

# Contributors

###### Anyone who contributed to this PR for future reference.

-Sebastian and Zachar 


# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
