### PR TITLE
Add total search result information to search result page

### DIFF
--- a/components/ResultsPage/ResultsLoader.tsx
+++ b/components/ResultsPage/ResultsLoader.tsx
@@ -27,7 +27,6 @@ interface ResultsLoaderProps {
   userInfo: UserInfo;
   onSignIn: (token: string) => void;
   fetchUserInfo: () => void;
-  totalResults: number;
 }
 
 export const getGroupedByTimeOfDay = (times): DayjsTuple[] => {
@@ -105,7 +104,6 @@ function ResultsLoader({
   userInfo,
   onSignIn,
   fetchUserInfo,
-  totalResults,
 }: ResultsLoaderProps): ReactElement {
   return (
     <InfiniteScroll
@@ -114,11 +112,6 @@ function ResultsLoader({
       hasMore={hasNextPage}
       loader={null}
     >
-      <div className="Results_Aggregation">
-        {totalResults === 1
-          ? `${totalResults} result`
-          : `${totalResults} results`}
-      </div>
       <div className="five column row">
         <div className="page-home">
           {results

--- a/components/ResultsPage/ResultsLoader.tsx
+++ b/components/ResultsPage/ResultsLoader.tsx
@@ -27,6 +27,7 @@ interface ResultsLoaderProps {
   userInfo: UserInfo;
   onSignIn: (token: string) => void;
   fetchUserInfo: () => void;
+  totalResults: number;
 }
 
 export const getGroupedByTimeOfDay = (times): DayjsTuple[] => {
@@ -104,6 +105,7 @@ function ResultsLoader({
   userInfo,
   onSignIn,
   fetchUserInfo,
+  totalResults,
 }: ResultsLoaderProps): ReactElement {
   return (
     <InfiniteScroll
@@ -112,6 +114,11 @@ function ResultsLoader({
       hasMore={hasNextPage}
       loader={null}
     >
+      <div className="Results_Aggregation">
+        {totalResults === 1
+          ? `${totalResults} result`
+          : `${totalResults} results`}
+      </div>
       <div className="five column row">
         <div className="page-home">
           {results

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -213,6 +213,13 @@ exports[`should render a section 1`] = `
           </div>
           <div className=\\"Results_SidebarSpacer\\" />
           <div className=\\"Results_Main\\">
+            <div className=\\"Results_Aggregation\\">
+              <TotalResultsDisplay>
+                <p>
+                  0 results
+                </p>
+              </TotalResultsDisplay>
+            </div>
             <LoadingContainer>
               <div style={{...}} />
             </LoadingContainer>

--- a/pages/[campus]/[termId]/search/[query].tsx
+++ b/pages/[campus]/[termId]/search/[query].tsx
@@ -100,6 +100,31 @@ export default function Results(): ReactElement | null {
     }`;
   };
 
+  const getTotalResults = (): number => {
+    /* 
+      Using the subject filter here to get the total number of search results because:
+      - the results themselves are loaded 10 at a time
+      - classes don't overlap across subjects
+    */
+    const options = searchData?.filterOptions['subject'] || [];
+    const selected = filters['subject'];
+
+    if (selected.length > 0) {
+      const selectedOptions = options.filter((option) =>
+        selected.includes(option.value)
+      );
+      return selectedOptions.reduce(
+        (total_aggregation, option) => total_aggregation + option.count,
+        0
+      );
+    }
+
+    return options.reduce(
+      (total_aggregation, option) => total_aggregation + option.count,
+      0
+    );
+  };
+
   macros.log(searchData);
 
   return (
@@ -147,6 +172,7 @@ export default function Results(): ReactElement | null {
               userInfo={userInfo}
               onSignIn={onSignIn}
               fetchUserInfo={fetchUserInfo}
+              totalResults={getTotalResults()}
             />
           )}
           <Footer />

--- a/pages/[campus]/[termId]/search/[query].tsx
+++ b/pages/[campus]/[termId]/search/[query].tsx
@@ -125,6 +125,17 @@ export default function Results(): ReactElement | null {
     );
   };
 
+  const TotalResultsDisplay = (): ReactElement => {
+    const totalResults = getTotalResults();
+    return (
+      <p>
+        {totalResults === 1
+          ? `${totalResults} result`
+          : `${totalResults} results`}
+      </p>
+    );
+  };
+
   macros.log(searchData);
 
   return (
@@ -153,8 +164,17 @@ export default function Results(): ReactElement | null {
           </>
         )}
         <div className="Results_Main">
-          {filtersAreSet && (
-            <FilterPills filters={filters} setFilters={setQParams} />
+          {filtersAreSet ? (
+            <>
+              <FilterPills filters={filters} setFilters={setQParams} />
+              <div className="Results_Aggregation__withFilters">
+                <TotalResultsDisplay />
+              </div>
+            </>
+          ) : (
+            <div className="Results_Aggregation">
+              <TotalResultsDisplay />
+            </div>
           )}
           {!searchData && <LoadingContainer />}
           {searchData && searchData.results.length === 0 && (
@@ -172,7 +192,6 @@ export default function Results(): ReactElement | null {
               userInfo={userInfo}
               onSignIn={onSignIn}
               fetchUserInfo={fetchUserInfo}
-              totalResults={getTotalResults()}
             />
           )}
           <Footer />

--- a/styles/_FilterPills.scss
+++ b/styles/_FilterPills.scss
@@ -28,6 +28,7 @@
     color: #d41b2c;
     padding: 0 10px;
     line-height: 30px;
+    background: rgba(255, 255, 255, 0);
   }
 
   &__clear:hover {

--- a/styles/pages/_Results.scss
+++ b/styles/pages/_Results.scss
@@ -152,6 +152,15 @@ $SIDEBAR_WIDTH: 268px;
   text-align: right;
   padding-right: 14px;
   margin-bottom: -7px;
+
+  &__withFilters {
+    font-style: italic;
+    font-family: Lato;
+    text-align: right;
+    padding-right: 14px;
+    margin-bottom: -7px;
+    margin-top: -22px;
+  }
 }
 
 .Breadcrumb_Container {

--- a/styles/pages/_Results.scss
+++ b/styles/pages/_Results.scss
@@ -154,11 +154,7 @@ $SIDEBAR_WIDTH: 268px;
   margin-bottom: -7px;
 
   &__withFilters {
-    font-style: italic;
-    font-family: Lato;
-    text-align: right;
-    padding-right: 14px;
-    margin-bottom: -7px;
+    @extend .Results_Aggregation;
     margin-top: -22px;
   }
 }

--- a/styles/pages/_Results.scss
+++ b/styles/pages/_Results.scss
@@ -146,6 +146,14 @@ $SIDEBAR_WIDTH: 268px;
   font-size: inherit !important;
 }
 
+.Results_Aggregation {
+  font-style: italic;
+  font-family: Lato;
+  text-align: right;
+  padding-right: 14px;
+  margin-bottom: -7px;
+}
+
 .Breadcrumb_Container {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
# Purpose

We want users to be able to better understand how many search results are being loaded and could potentially populate the infinite scroll container on the results page.


# Tickets

- https://trello.com/c/65DClxKh/159-add-total-search-result-information-to-search-result-page

# Contributors

- @puneetjohal 

# Feature List

- Adds a small indicator near the top right corner of the page stating how many results there are according to the current search query and filter state.

# Notes

Multiple results with no filters:
![image](https://user-images.githubusercontent.com/33487680/154409394-4bec7369-2cb2-49a8-a99e-c2b5c4b94d75.png)

Multiple results with filters applied:
![image](https://user-images.githubusercontent.com/33487680/154409473-1a1a5411-1419-4a00-aec0-f2d5f82f2278.png)

Exactly one result:
![image](https://user-images.githubusercontent.com/33487680/154409551-1d601b31-be5d-46c1-bef0-a761d862072d.png)

No results:
![image](https://user-images.githubusercontent.com/33487680/154409666-a155dcc3-7fff-40bd-9f4c-d0f29fecce01.png)

<br>

# Checklist

- [x] Filled out PR template :wink:
- [x] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
