### PR TITLE
switch total results to use total count

### DIFF
--- a/components/ResultsPage/useSearch.ts
+++ b/components/ResultsPage/useSearch.ts
@@ -100,6 +100,7 @@ export default function useSearch({
 
   const returnedData = data && {
     filterOptions: data[0].filterOptions,
+    totalCount: data[0].totalCount,
     results: data.map((d) => d.results).flat(),
     hasNextPage: data[0].hasNextPage,
   };
@@ -115,6 +116,7 @@ function transformGraphQLToSearchResult(
 ): SearchResult {
   const transformedResults: SearchResult = {
     results: [],
+    totalCount: graphqlResults.search.totalCount,
     filterOptions: graphqlResults.search.filterOptions as FilterOptions,
     hasNextPage: graphqlResults.search.pageInfo.hasNextPage,
   };

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -214,11 +214,7 @@ exports[`should render a section 1`] = `
           <div className=\\"Results_SidebarSpacer\\" />
           <div className=\\"Results_Main\\">
             <div className=\\"Results_Aggregation\\">
-              <TotalResultsDisplay>
-                <p>
-                  0 results
-                </p>
-              </TotalResultsDisplay>
+              <TotalResultsDisplay />
             </div>
             <LoadingContainer>
               <div style={{...}} />

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -216,7 +216,7 @@ exports[`should render a section 1`] = `
             <div className=\\"Results_Aggregation\\">
               <TotalResultsDisplay>
                 <p>
-                  0 course results
+                  0 results
                 </p>
               </TotalResultsDisplay>
             </div>

--- a/components/types.ts
+++ b/components/types.ts
@@ -109,6 +109,7 @@ export enum MeetingType {
 // Represents the course and employee data returned by /search
 export interface SearchResult {
   results: SearchItem[];
+  totalCount: number;
   filterOptions: FilterOptions;
   hasNextPage: boolean;
 }
@@ -124,6 +125,7 @@ export type SearchItem = CourseResult | Employee;
 export function BLANK_SEARCH_RESULT(): SearchResult {
   return {
     results: [],
+    totalCount: 0,
     filterOptions: {
       nupath: [],
       subject: [],

--- a/pages/[campus]/[termId]/search/[query].tsx
+++ b/pages/[campus]/[termId]/search/[query].tsx
@@ -100,40 +100,22 @@ export default function Results(): ReactElement | null {
     }`;
   };
 
-  const getTotalResults = (): number => {
-    /* 
-      Using the subject filter here to get the total number of search results because:
-      - the results themselves are loaded 10 at a time
-      - classes don't overlap across subjects
-    */
-    const options = searchData?.filterOptions['subject'] || [];
-    const selected = filters['subject'];
-
-    if (selected.length > 0) {
-      const selectedOptions = options.filter((option) =>
-        selected.includes(option.value)
-      );
-      return selectedOptions.reduce(
-        (total_aggregation, option) => total_aggregation + option.count,
-        0
-      );
-    }
-
-    return options.reduce(
-      (total_aggregation, option) => total_aggregation + option.count,
-      0
-    );
-  };
-
   const TotalResultsDisplay = (): ReactElement => {
-    const totalResults = getTotalResults();
-    return (
-      <p>
-        {totalResults === 1
-          ? `${totalResults} course result`
-          : `${totalResults} course results`}
-      </p>
-    );
+    // This has to be a null safe because searchData can be undefined on mount
+    const totalResults = searchData?.totalCount || 0;
+    let totalResultsStr = '';
+    switch (totalResults) {
+      case 1:
+        totalResultsStr = ' result';
+        break;
+      case 10000:
+        totalResultsStr = '+ results';
+        break;
+      default:
+        totalResultsStr = ' results';
+        break;
+    }
+    return <p>{totalResults.toLocaleString('en-US') + totalResultsStr}</p>;
   };
 
   macros.log(searchData);

--- a/pages/[campus]/[termId]/search/[query].tsx
+++ b/pages/[campus]/[termId]/search/[query].tsx
@@ -102,7 +102,13 @@ export default function Results(): ReactElement | null {
 
   const TotalResultsDisplay = (): ReactElement => {
     // This has to be a null safe because searchData can be undefined on mount
-    const totalResults = searchData?.totalCount || 0;
+    const totalResults = searchData?.totalCount;
+    if (totalResults === undefined) {
+      // if it is undefined, dont render results
+      return <></>;
+    }
+    // our ES index has a cap of 10,000 results for any search regardless of
+    // pagination. Therefore, if we get the max, we add a + to indicate possibly more.
     let totalResultsStr = '';
     switch (totalResults) {
       case 1:


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.
Switches from calculating total results from aggregations in filters to totalCount field on the searchResults graphql API, which is based on total hits from ES
<br>

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- Could not find one tho there may be one 🤔 

# Contributors

###### Anyone who contributed to this PR for future reference.

- @andrewydai 

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Switches total results to use total count
- Removes that function
- Formats the string 

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

ES generally has a 10,000 result limit regardless of pagination, so if 10,000 results return I added a + marker.

<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu

![image](https://user-images.githubusercontent.com/54340810/161880562-37e37b6f-48b1-48a5-be92-675dc91d7bf7.png)
