### PR TITLE
Visual Indication for API Errors

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -57,8 +57,8 @@ function Footer() {
           )
         </div>
         <div className="footer ui basic center aligned segment affiliation">
-          Search NEU is built for students by students & is not affiliated with
-          NEU.
+          Search NEU is built for students by students &amp; is not affiliated
+          with NEU.
         </div>
         <div className="footer ui basic center aligned segment contact">
           <a role="button" tabIndex={0} onClick={toggleModal}>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -24,7 +24,7 @@ import {
 } from '../components/types';
 import { campusToColor } from '../utils/campusToColor';
 import MobileSearchOverlay from './ResultsPage/MobileSearchOverlay';
-import getTermInfos from '../utils/TermInfoProvider';
+import getTermInfosWithError from '../utils/TermInfoProvider';
 import IconUser from './icons/IconUser';
 
 type HeaderProps = {
@@ -54,7 +54,7 @@ export default function Header({
   const campus = router.query.campus as string;
 
   // Get the TermInfo dict from the app context
-  const termInfos = getTermInfos();
+  const termInfos = getTermInfosWithError().termInfos;
 
   const [qParams, setQParams] = useQueryParams(QUERY_PARAM_ENCODERS);
   const filters: FilterSelection = merge({}, DEFAULT_FILTER_SELECTION, qParams);

--- a/components/HomePage/ExploratorySearchButton.tsx
+++ b/components/HomePage/ExploratorySearchButton.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { Campus } from '../types';
 import { useRouter } from 'next/router';
 import { getTermName } from '../terms';
-import getTermInfos from '../../utils/TermInfoProvider';
+import getTermInfosWithError from '../../utils/TermInfoProvider';
 
 interface ExploratorySearchButtonProps {
   termId: string;
@@ -15,7 +15,9 @@ const ExploratorySearchButton = ({
 }: ExploratorySearchButtonProps): ReactElement => {
   const router = useRouter();
 
-  const termInfos = getTermInfos();
+  const termInfosWithError = getTermInfosWithError();
+  const termInfosError = termInfosWithError.error;
+  const termInfos = termInfosWithError.termInfos;
   const termName = getTermName(termInfos, termId);
 
   return (
@@ -23,7 +25,7 @@ const ExploratorySearchButton = ({
       className="searchByFilters"
       onClick={() => router.push(`/${campus}/${termId}/search`)}
     >
-      {(!campus || !termName) && 'Loading semester data...'}
+      {(!campus || !termName) && !termInfosError && 'Loading semester data...'}
       {campus && termName && (
         <span>
           View all classes for

--- a/components/HomePage/HomeSearch.tsx
+++ b/components/HomePage/HomeSearch.tsx
@@ -9,7 +9,7 @@ import IconTie from '../icons/IconTie';
 import SearchBar from '../ResultsPage/SearchBar';
 import SearchDropdown from '../ResultsPage/SearchDropdown';
 import { Campus } from '../types';
-import getTermInfos from '../../utils/TermInfoProvider';
+import getTermInfosWithError from '../../utils/TermInfoProvider';
 
 interface HomeSearchProps {
   termId: string;
@@ -17,7 +17,8 @@ interface HomeSearchProps {
 }
 
 const HomeSearch = ({ termId, campus }: HomeSearchProps): ReactElement => {
-  const termInfos = getTermInfos();
+  const termInfosWithError = getTermInfosWithError();
+  const termInfos = termInfosWithError.termInfos;
 
   const campusLink = (c: Campus): string =>
     `/${c}/${getRoundedTerm(termInfos, c, termId)}`;

--- a/components/ResultsPage/useSearch.ts
+++ b/components/ResultsPage/useSearch.ts
@@ -22,7 +22,7 @@ export interface SearchParams {
   filters: FilterSelection;
 }
 interface UseSearchReturn {
-  error: any;
+  error: Error;
   searchData: SearchResult;
   loadMore: () => void;
 }

--- a/components/ResultsPage/useSearch.ts
+++ b/components/ResultsPage/useSearch.ts
@@ -22,6 +22,7 @@ export interface SearchParams {
   filters: FilterSelection;
 }
 interface UseSearchReturn {
+  error: any;
   searchData: SearchResult;
   loadMore: () => void;
 }
@@ -77,7 +78,7 @@ export default function useSearch({
     });
   };
 
-  const { data, size, setSize } = useSWRInfinite(
+  const { data, size, setSize, error } = useSWRInfinite(
     getKey,
     async (params): Promise<SearchResult> => {
       params = JSON.parse(params);
@@ -106,6 +107,7 @@ export default function useSearch({
   };
 
   return {
+    error: error,
     searchData: returnedData,
     loadMore: () => setSize((s) => s + 1),
   };

--- a/components/terms.ts
+++ b/components/terms.ts
@@ -15,7 +15,7 @@ export interface TermInfo {
  * Queries the backend for information about the terms for all campuses
  */
 export async function fetchTermInfo(): Promise<{
-  error: Error;
+  error: Error | null;
   termInfos: Record<Campus, TermInfo[]>;
 }> {
   // Creates a dict of {campus : TermInfo[] }

--- a/components/terms.ts
+++ b/components/terms.ts
@@ -15,7 +15,7 @@ export interface TermInfo {
  * Queries the backend for information about the terms for all campuses
  */
 export async function fetchTermInfo(): Promise<{
-  error: any;
+  error: Error;
   termInfos: Record<Campus, TermInfo[]>;
 }> {
   // Creates a dict of {campus : TermInfo[] }

--- a/components/terms.ts
+++ b/components/terms.ts
@@ -14,7 +14,10 @@ export interface TermInfo {
 /**
  * Queries the backend for information about the terms for all campuses
  */
-export async function fetchTermInfo(): Promise<Record<Campus, TermInfo[]>> {
+export async function fetchTermInfo(): Promise<{
+  error: any;
+  termInfos: Record<Campus, TermInfo[]>;
+}> {
   // Creates a dict of {campus : TermInfo[] }
   const allTermInfos = {
     [Campus.NEU]: [],
@@ -22,25 +25,33 @@ export async function fetchTermInfo(): Promise<Record<Campus, TermInfo[]>> {
     [Campus.LAW]: [],
   };
 
+  const termInfosWithError = {
+    error: null,
+    termInfos: allTermInfos,
+  };
+
   for (const college of Object.keys(Campus)) {
     // Query the TermInfos from the GraphQL client
-    const rawTermInfos = (
-      await gqlClient.getTermIDsByCollege({ subCollege: college })
-    )['termInfos'];
-
-    // Map the TermInfos to add a link parameter
-    const termInfos: TermInfo[] = rawTermInfos.map((term) => {
-      return {
-        text: term['text'],
-        value: term['termId'],
-        href: `/${college}/${term['termId']}`,
-      };
-    });
-
-    allTermInfos[college] = termInfos;
+    try {
+      const rawTermInfos = await gqlClient.getTermIDsByCollege({
+        subCollege: college,
+      });
+      // Map the TermInfos to add a link parameter
+      termInfosWithError.termInfos[college] = rawTermInfos['termInfos'].map(
+        (term) => {
+          return {
+            text: term['text'],
+            value: term['termId'],
+            href: `/${college}/${term['termId']}`,
+          };
+        }
+      );
+    } catch (e) {
+      termInfosWithError.error = e;
+    }
   }
 
-  return allTermInfos;
+  return termInfosWithError;
 }
 
 // Returns the latest (ie. most recent) term for the given campus

--- a/components/tests/integration/Home.test.jsx
+++ b/components/tests/integration/Home.test.jsx
@@ -25,9 +25,12 @@ jest.mock('next/router', () => ({
 
 // Mock service provider
 jest.mock('../../../utils/TermInfoProvider', () => () => ({
-  NEU: [{ text: TERM_TEXT, value: TERM_ID }],
-  CPS: [],
-  LAW: [],
+  error: null,
+  termInfos: {
+    NEU: [{ text: TERM_TEXT, value: TERM_ID }],
+    CPS: [],
+    LAW: [],
+  },
 }));
 /* 
 Mock axios using a mock adapter. For some reason I couldn't mock

--- a/components/tests/integration/Result.test.jsx
+++ b/components/tests/integration/Result.test.jsx
@@ -27,9 +27,12 @@ jest.mock('next/router', () => ({
 
 // Mock service provider
 jest.mock('../../../utils/TermInfoProvider', () => () => ({
-  NEU: [{ text: TERM_TEXT, value: TERM_ID }],
-  CPS: [],
-  LAW: [],
+  error: null,
+  termInfos: {
+    NEU: [{ text: TERM_TEXT, value: TERM_ID }],
+    CPS: [],
+    LAW: [],
+  },
 }));
 
 // Mock GraphQL Client

--- a/components/tests/pages/__snapshots__/Home.test.js.snap
+++ b/components/tests/pages/__snapshots__/Home.test.js.snap
@@ -1,42 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`should render a section 1`] = `
-"<div>
-  <div className=\\"alertBannerContainer\\">
-    <AlertBanner alertBannerData={{...}} />
-  </div>
-  <div className=\\"home-container\\">
-    <Head>
-      <title>
-        Search NEU - 
-        NEU
-         
-      </title>
-    </Head>
-    <a href=\\"https://www.sandboxnu.com/\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\" className=\\"sandboxLogoContainer\\">
-      <Image src=\\"/images/sandbox-logo.png\\" alt=\\"sandbox logo\\" width={47} height={61} />
-    </a>
-    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu\\" className=\\"githubCornerContainer\\">
-      <svg width=\\"80\\" height=\\"80\\" viewBox=\\"0 0 250 250\\">
-        <path d=\\"M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z\\" />
-        <path d=\\"M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2\\" fill=\\"currentColor\\" className=\\"octopusArm\\" />
-        <path d=\\"M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z\\" fill=\\"currentColor\\" />
-      </svg>
-    </a>
-    <div>
-      <div className=\\"ui center spacing aligned icon header topHeader\\">
-        <div className=\\"centerTextContainer\\">
-          <Logo className=\\"logo\\" aria-label=\\"logo\\" campus=\\"NEU\\" />
-          <LoadingContainer />
-          <ExploratorySearchButton termId=\\"\\" campus=\\"NEU\\" />
+"<Fragment>
+  <div>
+    <div className=\\"alertBannerContainer\\">
+      <AlertBanner alertBannerData={{...}} />
+    </div>
+    <div className=\\"home-container\\">
+      <Head>
+        <title>
+          Search NEU - 
+          NEU
+           
+        </title>
+      </Head>
+      <a href=\\"https://www.sandboxnu.com/\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\" className=\\"sandboxLogoContainer\\">
+        <Image src=\\"/images/sandbox-logo.png\\" alt=\\"sandbox logo\\" width={47} height={61} />
+      </a>
+      <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu\\" className=\\"githubCornerContainer\\">
+        <svg width=\\"80\\" height=\\"80\\" viewBox=\\"0 0 250 250\\">
+          <path d=\\"M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z\\" />
+          <path d=\\"M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2\\" fill=\\"currentColor\\" className=\\"octopusArm\\" />
+          <path d=\\"M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z\\" fill=\\"currentColor\\" />
+        </svg>
+      </a>
+      <div>
+        <div className=\\"ui center spacing aligned icon header topHeader\\">
+          <div className=\\"centerTextContainer\\">
+            <Logo className=\\"logo\\" aria-label=\\"logo\\" campus=\\"NEU\\" />
+            <LoadingContainer />
+            <ExploratorySearchButton termId=\\"\\" campus=\\"NEU\\" />
+          </div>
+          <Husky className=\\"husky\\" campus=\\"NEU\\" aria-label=\\"husky\\" />
+          <div className=\\"bostonContainer\\">
+            <SvgBoston className=\\"boston\\" aria-label=\\"logo\\" />
+          </div>
         </div>
-        <Husky className=\\"husky\\" campus=\\"NEU\\" aria-label=\\"husky\\" />
-        <div className=\\"bostonContainer\\">
-          <SvgBoston className=\\"boston\\" aria-label=\\"logo\\" />
-        </div>
+        <Memo(Footer) />
       </div>
-      <Memo(Footer) />
     </div>
   </div>
-</div>"
+  <FeedbackModal toggleForm={[Function: toggleModal]} feedbackModalOpen={false} />
+</Fragment>"
 `;

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -306,6 +306,31 @@ exports[`should render a section 1`] = `
         </div>
         <div className=\\"botttomPadding\\" />
       </div>
+      <FeedbackModal toggleForm={[Function: toggleModal]} feedbackModalOpen={false}>
+        <div className=\\"feedback-container\\">
+          <Transition in={false} timeout={500} mountOnEnter={false} unmountOnExit={false} appear={false} enter={true} exit={true} onEnter={[Function: noop]} onEntering={[Function: noop]} onEntered={[Function: noop]} onExit={[Function: noop]} onExiting={[Function: noop]} onExited={[Function: noop]}>
+            <Message success={true} className=\\"alertMessage\\" header=\\"Your submission was successful.\\" style={{...}} onDismiss={[Function: bound hideMessage]}>
+              <div style={{...}} className=\\"ui success message alertMessage\\">
+                <Icon name=\\"close\\" onClick={[Function (anonymous)]} as=\\"i\\">
+                  <i onClick={[Function (anonymous)]} aria-hidden=\\"true\\" className=\\"close icon\\" />
+                </Icon>
+                <MessageContent>
+                  <div className=\\"content\\">
+                    <MessageHeader content=\\"Your submission was successful.\\">
+                      <div className=\\"header\\">
+                        Your submission was successful.
+                      </div>
+                    </MessageHeader>
+                  </div>
+                </MessageContent>
+              </div>
+            </Message>
+          </Transition>
+          <Modal open={false} onClose={[Function: toggleModal]} size=\\"small\\" className=\\"feedback-modal-container\\" centered={true} dimmer={true} closeOnDimmerClick={true} closeOnDocumentClick={false} eventPool=\\"Modal\\">
+            <Portal closeOnDocumentClick={false} trigger={[undefined]} eventPool=\\"Modal\\" mountNode={{...}} open={false} onClose={[Function (anonymous)]} onMount={[Function (anonymous)]} onOpen={[Function (anonymous)]} onUnmount={[Function (anonymous)]} closeOnEscape={true} openOnTriggerClick={true} />
+          </Modal>
+        </div>
+      </FeedbackModal>
     </Results>
   </LocationProvider>
 </QueryParamProvider>"

--- a/pages/[campus]/[termId].tsx
+++ b/pages/[campus]/[termId].tsx
@@ -6,7 +6,7 @@ import { GetStaticPathsResult, GetStaticProps } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import Footer from '../../components/Footer';
 import { fetchTermInfo } from '../../components/terms';
 import HomeSearch from '../../components/HomePage/HomeSearch';
@@ -14,21 +14,23 @@ import ExploratorySearchButton from '../../components/HomePage/ExploratorySearch
 import Boston from '../../components/icons/boston.svg';
 import Husky from '../../components/icons/Husky';
 import Logo from '../../components/icons/Logo';
-import macros from '../../components/macros';
 import LoadingContainer from '../../components/ResultsPage/LoadingContainer';
 import AlertBanner, {
   AlertBannerData,
 } from '../../components/common/AlertBanner';
 import { Campus } from '../../components/types';
 import alertBannersData from '../../public/alert-banners.yml';
+import FeedbackModal from '../../components/FeedbackModal';
 
-import getTermInfos from '../../utils/TermInfoProvider';
+import getTermInfosWithError from '../../utils/TermInfoProvider';
 
 export default function Home(): ReactElement {
   const router = useRouter();
 
   const campus = (router.query.campus as Campus) || Campus.NEU;
-  const termInfos = getTermInfos();
+  const termInfosWithError = getTermInfosWithError();
+  const termInfosError = termInfosWithError.error;
+  const termInfos = termInfosWithError.termInfos;
   const LATEST_TERM =
     termInfos[campus].length > 0 ? termInfos[campus][0]['value'] : '';
   const termId = (router.query.termId as string) || LATEST_TERM;
@@ -37,80 +39,97 @@ export default function Home(): ReactElement {
 
   const containerClassnames = 'home-container';
 
-  return (
-    <div>
-      <div className="alertBannerContainer">
-        {alertBanners.map((alertBanner) => (
-          <AlertBanner key={alertBanner.text} alertBannerData={alertBanner} />
-        ))}
-      </div>
-      <div className={containerClassnames}>
-        {/*TODO: remove when notification is fixed */}
-        <Head>
-          <title>Search NEU - {campus} </title>
-        </Head>
-        <a
-          href="https://www.sandboxnu.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="sandboxLogoContainer"
-        >
-          <Image
-            src="/images/sandbox-logo.png"
-            alt="sandbox logo"
-            width={47}
-            height={61}
-          />
-        </a>
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://github.com/sandboxnu/searchneu"
-          className="githubCornerContainer"
-        >
-          <svg width="80" height="80" viewBox="0 0 250 250">
-            <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z" />
-            <path
-              d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
-              fill="currentColor"
-              className="octopusArm"
-            />
-            <path
-              d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
-              fill="currentColor"
-            />
-          </svg>
-        </a>
+  const [modalOpen, setModalOpen] = useState(false);
 
-        <div>
-          <div // TODO: Take this out and restyle this monstrosity from scratch
-            className="ui center spacing aligned icon header topHeader"
+  const toggleModal = () => {
+    setModalOpen(!modalOpen);
+  };
+
+  return (
+    <>
+      <div>
+        <div className="alertBannerContainer">
+          {alertBanners.map((alertBanner) => (
+            <AlertBanner key={alertBanner.text} alertBannerData={alertBanner} />
+          ))}
+        </div>
+        <div className={containerClassnames}>
+          {/*TODO: remove when notification is fixed */}
+          <Head>
+            <title>Search NEU - {campus} </title>
+          </Head>
+          <a
+            href="https://www.sandboxnu.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="sandboxLogoContainer"
           >
-            <div className="centerTextContainer">
-              <Logo className="logo" aria-label="logo" campus={campus} />
-              {termInfos[campus].length == 0 ? (
-                <LoadingContainer />
-              ) : (
-                <HomeSearch termId={termId} campus={campus} />
-              )}
-              <ExploratorySearchButton termId={termId} campus={campus} />
+            <Image
+              src="/images/sandbox-logo.png"
+              alt="sandbox logo"
+              width={47}
+              height={61}
+            />
+          </a>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/sandboxnu/searchneu"
+            className="githubCornerContainer"
+          >
+            <svg width="80" height="80" viewBox="0 0 250 250">
+              <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z" />
+              <path
+                d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+                fill="currentColor"
+                className="octopusArm"
+              />
+              <path
+                d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+                fill="currentColor"
+              />
+            </svg>
+          </a>
+
+          <div>
+            <div // TODO: Take this out and restyle this monstrosity from scratch
+              className="ui center spacing aligned icon header topHeader"
+            >
+              <div className="centerTextContainer">
+                <Logo className="logo" aria-label="logo" campus={campus} />
+                {termInfosError !== null ? (
+                  <div>
+                    <h3> An Error Occurred : ( </h3>
+                    <a role="button" onClick={toggleModal}>
+                      Report a bug
+                    </a>
+                  </div>
+                ) : termInfos[campus].length == 0 ? (
+                  <LoadingContainer />
+                ) : (
+                  <HomeSearch termId={termId} campus={campus} />
+                )}
+                <ExploratorySearchButton termId={termId} campus={campus} />
+              </div>
+              <Husky className="husky" campus={campus} aria-label="husky" />
+              <div className="bostonContainer">
+                <Boston className="boston" aria-label="logo" />
+              </div>
             </div>
-            <Husky className="husky" campus={campus} aria-label="husky" />
-            <div className="bostonContainer">
-              <Boston className="boston" aria-label="logo" />
-            </div>
+            <Footer />
           </div>
-          <Footer />
         </div>
       </div>
-    </div>
+      <FeedbackModal toggleForm={toggleModal} feedbackModalOpen={modalOpen} />
+    </>
   );
 }
 
 // Tells Next what to statically optimize
 export async function getStaticPaths(): Promise<GetStaticPathsResult> {
   const result: GetStaticPathsResult = { paths: [], fallback: false };
-  const termInfos = await fetchTermInfo();
+  const termInfosWithError = await fetchTermInfo();
+  const termInfos = termInfosWithError.termInfos;
 
   for (const campus of Object.values(Campus)) {
     for (const termId of termInfos[campus]) {

--- a/pages/[campus]/[termId].tsx
+++ b/pages/[campus]/[termId].tsx
@@ -6,7 +6,7 @@ import { GetStaticPathsResult, GetStaticProps } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 import Footer from '../../components/Footer';
 import { fetchTermInfo } from '../../components/terms';
 import HomeSearch from '../../components/HomePage/HomeSearch';
@@ -20,7 +20,6 @@ import AlertBanner, {
 } from '../../components/common/AlertBanner';
 import { Campus } from '../../components/types';
 import alertBannersData from '../../public/alert-banners.yml';
-import FeedbackModal from '../../components/FeedbackModal';
 
 import getTermInfosWithError from '../../utils/TermInfoProvider';
 
@@ -38,12 +37,6 @@ export default function Home(): ReactElement {
   const alertBanners = Object.values(alertBannersData) as [AlertBannerData];
 
   const containerClassnames = 'home-container';
-
-  const [modalOpen, setModalOpen] = useState(false);
-
-  const toggleModal = () => {
-    setModalOpen(!modalOpen);
-  };
 
   return (
     <>
@@ -100,9 +93,6 @@ export default function Home(): ReactElement {
                 {termInfosError !== null ? (
                   <div>
                     <h3> An Error Occurred : ( </h3>
-                    <a role="button" onClick={toggleModal}>
-                      Report a bug
-                    </a>
                   </div>
                 ) : termInfos[campus].length == 0 ? (
                   <LoadingContainer />
@@ -120,7 +110,6 @@ export default function Home(): ReactElement {
           </div>
         </div>
       </div>
-      <FeedbackModal toggleForm={toggleModal} feedbackModalOpen={modalOpen} />
     </>
   );
 }

--- a/pages/[campus]/[termId].tsx
+++ b/pages/[campus]/[termId].tsx
@@ -6,7 +6,7 @@ import { GetStaticPathsResult, GetStaticProps } from 'next';
 import Head from 'next/head';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import Footer from '../../components/Footer';
 import { fetchTermInfo } from '../../components/terms';
 import HomeSearch from '../../components/HomePage/HomeSearch';
@@ -20,6 +20,7 @@ import AlertBanner, {
 } from '../../components/common/AlertBanner';
 import { Campus } from '../../components/types';
 import alertBannersData from '../../public/alert-banners.yml';
+import FeedbackModal from '../../components/FeedbackModal';
 
 import getTermInfosWithError from '../../utils/TermInfoProvider';
 
@@ -37,6 +38,12 @@ export default function Home(): ReactElement {
   const alertBanners = Object.values(alertBannersData) as [AlertBannerData];
 
   const containerClassnames = 'home-container';
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const toggleModal = () => {
+    setModalOpen(!modalOpen);
+  };
 
   return (
     <>
@@ -93,6 +100,9 @@ export default function Home(): ReactElement {
                 {termInfosError !== null ? (
                   <div>
                     <h3> An Error Occurred : ( </h3>
+                    <a role="button" onClick={toggleModal}>
+                      Report a bug
+                    </a>
                   </div>
                 ) : termInfos[campus].length == 0 ? (
                   <LoadingContainer />
@@ -110,6 +120,7 @@ export default function Home(): ReactElement {
           </div>
         </div>
       </div>
+      <FeedbackModal toggleForm={toggleModal} feedbackModalOpen={modalOpen} />
     </>
   );
 }

--- a/pages/api/sitemap.xml.ts
+++ b/pages/api/sitemap.xml.ts
@@ -29,7 +29,8 @@ async function generateSitemap(): Promise<string> {
   // The part after the https://searchneu.com/
   const items: Set<string> = new Set();
 
-  const termInfos = await fetchTermInfo();
+  const termInfosWithError = await fetchTermInfo();
+  const termInfos = termInfosWithError.termInfos;
 
   // latest terms for each campus
   const latestTerms: [Campus, string][] = Object.values(Campus).map((c) => [

--- a/styles/pages/_Home.scss
+++ b/styles/pages/_Home.scss
@@ -41,7 +41,6 @@
     margin-bottom: 0 !important;
     height: 100vh;
     position: relative;
-    pointer-events: none;
     background: linear-gradient(
       180deg,
       rgba(168, 218, 220, 0.66) 3.86%,
@@ -116,6 +115,7 @@
     text-align: center;
     line-height: 0;
     z-index: 8;
+    pointer-events: none;
   }
 
   .boston {

--- a/styles/pages/_Home.scss
+++ b/styles/pages/_Home.scss
@@ -41,6 +41,7 @@
     margin-bottom: 0 !important;
     height: 100vh;
     position: relative;
+    pointer-events: none;
     background: linear-gradient(
       180deg,
       rgba(168, 218, 220, 0.66) 3.86%,

--- a/styles/pages/_Home.scss
+++ b/styles/pages/_Home.scss
@@ -41,7 +41,6 @@
     margin-bottom: 0 !important;
     height: 100vh;
     position: relative;
-    pointer-events: none;
     background: linear-gradient(
       180deg,
       rgba(168, 218, 220, 0.66) 3.86%,

--- a/utils/TermInfoProvider.tsx
+++ b/utils/TermInfoProvider.tsx
@@ -32,7 +32,7 @@ TermInfoProvider.propTypes = {
 };
 
 const GetTermInfosWithError = (): {
-  error: any;
+  error: Error;
   termInfos: Record<Campus, TermInfo[]>;
 } => useContext(termInfoReactContext);
 export default GetTermInfosWithError;

--- a/utils/TermInfoProvider.tsx
+++ b/utils/TermInfoProvider.tsx
@@ -9,10 +9,15 @@ const emptyTermInfos: Record<Campus, TermInfo[]> = {
   [Campus.LAW]: [],
 };
 
-const termInfoReactContext = React.createContext(emptyTermInfos);
+const emptyTermInfosWithError = {
+  error: null,
+  termInfos: emptyTermInfos,
+};
+
+const termInfoReactContext = React.createContext(emptyTermInfosWithError);
 
 export const TermInfoProvider = ({ children }): ReactElement => {
-  const [termInfos, setTermInfos] = useState(emptyTermInfos);
+  const [termInfos, setTermInfos] = useState(emptyTermInfosWithError);
 
   useEffect(() => {
     fetchTermInfo().then((result) => setTermInfos(result));
@@ -26,6 +31,8 @@ TermInfoProvider.propTypes = {
   children: PropTypes.node,
 };
 
-const GetTermInfos = (): Record<Campus, TermInfo[]> =>
-  useContext(termInfoReactContext);
-export default GetTermInfos;
+const GetTermInfosWithError = (): {
+  error: any;
+  termInfos: Record<Campus, TermInfo[]>;
+} => useContext(termInfoReactContext);
+export default GetTermInfosWithError;


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br>Adds visual indication in the frontend when our API fails (to replace the infinite loading screen). 
<img width="1422" alt="Screen Shot 2022-10-02 at 9 42 51 PM" src="https://user-images.githubusercontent.com/57331456/193494207-68b2d6f5-5270-4124-b20c-ca4e16cf36a6.png">
<img width="1416" alt="Screen Shot 2022-10-02 at 9 44 43 PM" src="https://user-images.githubusercontent.com/57331456/193494213-c69cba53-8aaa-40cc-851c-1e3f3cb561e1.png">


# Tickets

###### A link to any tickets this PR is associated with on Trello.
[Set timeout for semester API loading](https://trello.com/c/CLORH0Xe/326-set-timeout-for-semester-api-loading)

# Contributors

###### Anyone who contributed to this PR for future reference.

- @tiingweii-shii 

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Displays "An Error Occurred : (" with a "Report a Bug" button on Home and Search page when the API fails.

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

<br> Maybe update the design for the error message

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
