### PR TITLE
fix tooltip border radius being overwritten

### DIFF
--- a/styles/home/_HomeSearch.scss
+++ b/styles/home/_HomeSearch.scss
@@ -87,14 +87,14 @@
       width: 100%;
       display: flex;
 
-      & > div {
+      .searchbar {
         height: 100%;
         width: 100%;
         background: #f5f5f5;
         border-top: none;
         border-bottom: none;
 
-        & > div {
+        .searchbar__button {
           width: 54px;
         }
 
@@ -106,7 +106,7 @@
         @media only screen and (min-width: 830px) {
           border-radius: 0 5px 5px 0;
 
-          & > div {
+          .searchbar__button {
             border-radius: 0 5px 5px 0;
           }
         }


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br> The tooltip border was being overwritten by some styles on the searchbar, so I changed the styles to use classnames instead of using just "div".

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- N/A

# Contributors

###### Anyone who contributed to this PR for future reference.

- @sebwittr 

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Added classnames within the CSS instead of using div.
-
-

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

<br>

# Checklist

- [x] Filled out PR template :wink:
- [x] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>

Old Tooltip:
![image](https://user-images.githubusercontent.com/79394243/200208641-e07af7bb-903c-4013-8bfd-aaf7e9213bcc.png)

New Tooltip: 
![image](https://user-images.githubusercontent.com/79394243/200208670-79cc932e-1128-499b-9d52-07cbc02ddc1d.png)

@sandboxnu/searchneu
