### PR TITLE
Semesters Names Inconsistency on Law/CPS Class Pages

### DIFF
--- a/components/ClassPage/ClassPageInfoBody.tsx
+++ b/components/ClassPage/ClassPageInfoBody.tsx
@@ -1,7 +1,11 @@
 import { mean } from 'lodash';
 import React, { ReactElement } from 'react';
 import { GetClassPageInfoQuery } from '../../generated/graphql';
-import { getCampusByLastDigit, getSeason, getYear } from '../terms';
+import {
+  getCampusByLastDigit,
+  getSemesterNameFromTermId,
+  getYearFromTermId,
+} from '../terms';
 import { Campus } from '../types';
 import HeaderBody from './HeaderBody';
 
@@ -106,7 +110,7 @@ function getRecentSemesterNames(
 ): string[] {
   const allSemesters = classPageInfo.class.allOccurrences.map((occurrence) => {
     const termId = occurrence.termId.toString();
-    return `${getSeason(termId)} ${getYear(termId)}`;
+    return `${getSemesterNameFromTermId(termId)} ${getYearFromTermId(termId)}`;
   });
   return allSemesters.slice(0, Math.min(limit, allSemesters.length));
 }

--- a/components/ClassPage/ClassPageInfoBody.tsx
+++ b/components/ClassPage/ClassPageInfoBody.tsx
@@ -1,13 +1,10 @@
 import { mean } from 'lodash';
 import React, { ReactElement } from 'react';
 import { GetClassPageInfoQuery } from '../../generated/graphql';
-import {
-  getCampusByLastDigit,
-  getSemesterNameFromTermId,
-  getYearFromTermId,
-} from '../terms';
+import { getTermNameFromId } from '../terms';
 import { Campus } from '../types';
 import HeaderBody from './HeaderBody';
+import { router } from 'next/client';
 
 type ClassPageInfoProp = {
   classPageInfo: GetClassPageInfoQuery;
@@ -24,10 +21,7 @@ export default function ClassPageInfoBody({
           header="COURSE DESCRIPTION"
           body={<p>{latestOccurrence.desc}</p>}
         />
-        <HeaderBody
-          header="COURSE LEVEL"
-          body={<p>{getCourseLevel(latestOccurrence.termId.toString())}</p>}
-        />
+        <HeaderBody header="COURSE LEVEL" body={<p>{getCourseLevel()}</p>} />
       </div>
       <div className="verticalLine" />
       <div className="classPageBodyRight">
@@ -76,9 +70,8 @@ export default function ClassPageInfoBody({
   );
 }
 
-function getCourseLevel(termId: string): string {
-  const termIdLastDigit = termId.charAt(termId.length - 1);
-  const campus = getCampusByLastDigit(termIdLastDigit);
+function getCourseLevel(): string {
+  const campus = (router?.query?.campus as Campus) ?? Campus.NEU;
   return campus === Campus.NEU ? 'Undergraduate' : 'Graduate';
 }
 
@@ -108,9 +101,10 @@ function getRecentSemesterNames(
   classPageInfo: GetClassPageInfoQuery,
   limit: number
 ): string[] {
+  const campus = (router?.query?.campus as Campus) ?? Campus.NEU;
   const allSemesters = classPageInfo.class.allOccurrences.map((occurrence) => {
     const termId = occurrence.termId.toString();
-    return `${getSemesterNameFromTermId(termId)} ${getYearFromTermId(termId)}`;
+    return `${getTermNameFromId(termId, campus)}`;
   });
   return allSemesters.slice(0, Math.min(limit, allSemesters.length));
 }

--- a/components/ClassPage/PageContent.tsx
+++ b/components/ClassPage/PageContent.tsx
@@ -5,6 +5,7 @@ import ClassPageInfoBody from './ClassPageInfoBody';
 import ClassPageInfoHeader from './ClassPageInfoHeader';
 import ClassPageReqsBody from './ClassPageReqsBody';
 import ClassPageSections from './ClassPageSections';
+import getTermInfos from '../../utils/TermInfoProvider';
 
 type PageContentProps = {
   termId: string;
@@ -28,8 +29,13 @@ export default function PageContent({
   // TODO: hacky front-end solution because for some reason allOccurrences includes
   // termIds where there are no sections. This should probably be fixed on the backend.
   if (classPageInfo && classPageInfo.class) {
+    const termIds = getTermInfos()[campus].map((termInfo) => termInfo.value);
     classPageInfo.class.allOccurrences = classPageInfo.class.allOccurrences.filter(
-      (occurrence) => occurrence.sections.length > 0
+      (occurrence) =>
+        occurrence.sections.length > 0 &&
+        // filter out termIds that are not availible from termInfos from Banner,
+        // probably should include this in the backend as well
+        termIds.includes(occurrence.termId)
     );
   }
   return (

--- a/components/ClassPage/SectionsTermNav.tsx
+++ b/components/ClassPage/SectionsTermNav.tsx
@@ -1,7 +1,9 @@
 import React, { ReactElement } from 'react';
 import { GetClassPageInfoQuery } from '../../generated/graphql';
-import { getSemesterNameFromTermId, getYearFromTermId } from '../terms';
+import { getTermNameFromId } from '../terms';
 import { LeftNavArrow, RightNavArrow } from '../icons/NavArrow';
+import { router } from 'next/client';
+import { Campus } from '../types';
 
 type sectionsTermNavProps = {
   currTermIndex: number;
@@ -19,6 +21,7 @@ export default function SectionsTermNav({
   const leftNavDisabled = (termIndex): boolean =>
     termIndex === allOccurrences.length - 1;
   const rightNavDisabled = (termIndex): boolean => termIndex === 0;
+  const campus = (router?.query?.campus as Campus) ?? Campus.NEU;
   return (
     <div className="termNav">
       <span
@@ -35,9 +38,7 @@ export default function SectionsTermNav({
           fill={leftNavDisabled(currTermIndex) ? '#969696' : '#000000'}
         />
       </span>
-      {`${getSemesterNameFromTermId(`${currTermId}`)} ${getYearFromTermId(
-        `${currTermId}`
-      )}`.toUpperCase()}
+      {`${getTermNameFromId(`${currTermId}`, `${campus}`)}`.toUpperCase()}
       <span
         onClick={() => setCurrTermIndex(Math.max(currTermIndex - 1, 0))}
         className={`navArrow ${

--- a/components/ClassPage/SectionsTermNav.tsx
+++ b/components/ClassPage/SectionsTermNav.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { GetClassPageInfoQuery } from '../../generated/graphql';
-import { getSeason, getYear } from '../terms';
+import { getSemesterNameFromTermId, getYearFromTermId } from '../terms';
 import { LeftNavArrow, RightNavArrow } from '../icons/NavArrow';
 
 type sectionsTermNavProps = {
@@ -35,7 +35,7 @@ export default function SectionsTermNav({
           fill={leftNavDisabled(currTermIndex) ? '#969696' : '#000000'}
         />
       </span>
-      {`${getSeason(`${currTermId}`)} ${getYear(
+      {`${getSemesterNameFromTermId(`${currTermId}`)} ${getYearFromTermId(
         `${currTermId}`
       )}`.toUpperCase()}
       <span

--- a/components/terms.ts
+++ b/components/terms.ts
@@ -126,26 +126,44 @@ export function getTermName(
   return termName ? termName.text : '';
 }
 
-export function getSeason(termId: string): string {
-  const seasonDigit = termId.charAt(termId.length - 2);
-  const seasonDigitMap = {
-    '1': 'Fall',
-    '2': 'Winter',
-    '3': 'Spring',
-    '4': 'Summer I',
-    '5': 'Summer Full',
-    '6': 'Summer II',
+/**
+ * CPS/LAW use different semester names than NEU.
+ * Current semester names for NEU campus: Fall, Winter, Spring, Summer I, Summer II, and Summer Full.
+ * Current semester names for CPS/LAW campus: Fall Semester, Fall Quarter, Winter Quarter,
+ * Spring Semester, Spring Quarter, Summer Semester, Summer Quarter.
+ * Each semester corresponds to a different 2-digits number (last two digits of the term id).
+ */
+export function getSemesterNameFromTermId(termId: string): string {
+  const semesterDigit = termId.slice(-2);
+  const semesterDigitMap = {
+    '10': 'Fall',
+    '14': 'Fall Semester',
+    '15': 'Fall Quarter',
+    '20': 'Winter',
+    '25': 'Winter Quarter',
+    '30': 'Spring',
+    '34': 'Spring Semester',
+    '35': 'Spring Quarter',
+    '40': 'Summer I',
+    '50': 'Summer Full',
+    '54': 'Summer Semester',
+    '55': 'Summer Quarter',
+    '60': 'Summer II',
   };
-  if (!seasonDigitMap[seasonDigit]) throw new Error('unexpected season digit');
-  else return seasonDigitMap[seasonDigit];
+
+  if (!semesterDigitMap[semesterDigit])
+    throw new Error('Unexpected season digit: ' + semesterDigit);
+  else return semesterDigitMap[semesterDigit];
 }
 
 // returns the year the term occurs in
-// ex: 202110 is Fall 2020 not Fall 2021
-export function getYear(termId: string): number {
+export function getYearFromTermId(termId: string): number {
   const givenYear: number = parseInt(termId.substr(0, 4));
-  const season = getSeason(termId);
-  if (season === 'Fall' || season === 'Winter') {
+  const seasonDigit: number = parseInt(termId.charAt(termId.length - 2));
+  // Fall and Winter semesters occurs in the previous year from the given year from termId.
+  // ex: 202110 should be Fall 2020 not Fall 2021
+  // Fall semesters have season digit 1; Winter semesters have season digit 2.
+  if (seasonDigit < 3) {
     return givenYear - 1;
   } else {
     return givenYear;

--- a/pages/[campus]/[termId].tsx
+++ b/pages/[campus]/[termId].tsx
@@ -14,7 +14,6 @@ import ExploratorySearchButton from '../../components/HomePage/ExploratorySearch
 import Boston from '../../components/icons/boston.svg';
 import Husky from '../../components/icons/Husky';
 import Logo from '../../components/icons/Logo';
-import macros from '../../components/macros';
 import LoadingContainer from '../../components/ResultsPage/LoadingContainer';
 import AlertBanner, {
   AlertBannerData,
@@ -27,7 +26,7 @@ import getTermInfos from '../../utils/TermInfoProvider';
 export default function Home(): ReactElement {
   const router = useRouter();
 
-  const campus = (router.query.campus as Campus) || Campus.NEU;
+  const campus = (router.query.campus as Campus) ?? Campus.NEU;
   const termInfos = getTermInfos();
   const LATEST_TERM =
     termInfos[campus].length > 0 ? termInfos[campus][0]['value'] : '';


### PR DESCRIPTION
# Purpose

<br> CPS/LAW use different semester names than NEU, but it is not reflected on course info pages. This PR addresses the semester name inconsistencies :)

The logic to get semester names was changed: we decide the semester name from its matching termId from termInfos of corresponding campus (college).
<img width="1435" alt="Screen Shot 2022-11-20 at 4 38 01 PM" src="https://user-images.githubusercontent.com/57331456/202927668-72a8f2bd-e7e9-44b1-b6aa-134d234287c0.png">

# Tickets

https://trello.com/c/G5MKa3nX/260-semesters-for-law-cps-classes-dont-match-up-on-class-pages

# Contributors

@tiingweii-shii 

# Feature List

- Updated the logic for getting semester names from termIds (to display correct semester names for CPS and LAW)

# Notes
- For some classes, banner gives sections for semesters that are not included in termInfos, so we need to filter out those sections. However, it is best to handle this in the backend. A ticket will be cut for this. See comment for details 👀
- Currently the CourseInfo page breaks (with a `LocationUndefined` error) whenever it is refreshed. Cabbage says Seb is working on a ticket that is related to this. 

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
