### PR TITLE
Add 7000 and 8000 ticks to the course id range filter

### DIFF
--- a/components/ResultsPage/RangeFilter.tsx
+++ b/components/ResultsPage/RangeFilter.tsx
@@ -16,7 +16,7 @@ export default function RangeFilter({
 }: RangeFilterProps): ReactElement {
   const [controlledInput, setControlledInput] = useState(selected);
 
-  const courseIDs = [1000, 2000, 3000, 4000, 5000, 6000];
+  const courseIDs = [1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000];
   const marks = {};
   courseIDs.forEach((id) => {
     marks[id] = id.toString();


### PR DESCRIPTION
# Purpose

As per #186, add the 7000 and 8000 ticks to the course id range filter slider so grad students can search for courses too.

# Contributors

Just me

# Notes

I haven't actually tested if the design *looks* any good, I literally `grep`'ed through the codebase, found the appropriate list, and added two numbers. Somebody with the whole dev environment setup should take a look at it first.

<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [x] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
