### PR TITLE
Fix visual toggle for notifications sign-up

### DIFF
--- a/components/notifications/SignUpForNotifications.tsx
+++ b/components/notifications/SignUpForNotifications.tsx
@@ -27,13 +27,6 @@ export default function SignUpForNotifications({
   showNotificationSignup,
   fetchUserInfo,
 }: SignUpForNotificationsProps): ReactElement {
-  userInfo = {
-    token: null,
-    phoneNumber: null,
-    courseIds: [],
-    sectionIds: [],
-  };
-
   const [showModal, setShowModal] = useState(false);
   const [requesting, setRequesting] = useState(false);
   const [checked, setChecked] = useState(

--- a/components/notifications/SignUpForNotifications.tsx
+++ b/components/notifications/SignUpForNotifications.tsx
@@ -3,13 +3,14 @@
  * See the license file in the root folder for details.
  */
 
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { UserInfo } from '../types';
 import Keys from '../Keys';
 import CourseCheckBox from '../panels/CourseCheckBox';
-import SignUpModal from './modal/SignUpModal';
+import SignUpModal, { Step } from './modal/SignUpModal';
 import NotifSignUpButton from '../ResultsPage/Results/NotifSignUpButton';
 import { Course } from '../types';
+import axios from 'axios';
 
 type SignUpForNotificationsProps = {
   course: Course;
@@ -26,10 +27,22 @@ export default function SignUpForNotifications({
   showNotificationSignup,
   fetchUserInfo,
 }: SignUpForNotificationsProps): ReactElement {
-  const [showModal, setShowModal] = useState(false);
+  userInfo = {
+    token: null,
+    phoneNumber: null,
+    courseIds: [],
+    sectionIds: [],
+  };
 
-  const checked =
-    userInfo && userInfo.courseIds.includes(Keys.getClassHash(course));
+  const [showModal, setShowModal] = useState(false);
+  const [requesting, setRequesting] = useState(false);
+  const [checked, setChecked] = useState(
+    userInfo && userInfo.courseIds.includes(Keys.getClassHash(course))
+  );
+
+  // useEffect(() => {
+  //   setChecked(userInfo && userInfo.courseIds.includes(Keys.getClassHash(course)));
+  // }, [userInfo]);
 
   const onNotifSignUp = (): void => {
     setShowModal(true);
@@ -47,17 +60,61 @@ export default function SignUpForNotifications({
       ? 'There is 1 section with seats left.'
       : `There are ${numOpenSections} sections with seats left.`;
 
+  function onCheckboxClick(): void {
+    if (requesting) return; // avoid race conditions by locking out other requests
+    setRequesting(true);
+
+    if (checked) {
+      setChecked(false); // switch before request to avoid lag
+      axios
+        .delete(
+          `${process.env.NEXT_PUBLIC_NOTIFS_ENDPOINT}/user/subscriptions`,
+          {
+            data: {
+              token: userInfo.token,
+              sectionIds: [],
+              courseIds: [Keys.getClassHash(course)],
+            },
+          }
+        )
+        .catch((e) => {
+          setShowModal(true);
+          setChecked(true);
+          console.error(e);
+        })
+        .then(() => fetchUserInfo())
+        .finally(() => setRequesting(false));
+    } else {
+      setChecked(true); // switch before request to avoid lag
+      axios
+        .put(`${process.env.NEXT_PUBLIC_NOTIFS_ENDPOINT}/user/subscriptions`, {
+          token: userInfo.token,
+          sectionIds: [],
+          courseIds: [Keys.getClassHash(course)],
+        })
+        .catch((e) => {
+          setShowModal(true);
+          setChecked(false);
+          console.error(e);
+        })
+        .then(() => fetchUserInfo())
+        .finally(() => setRequesting(false));
+    }
+  }
+
   return showNotificationSignup ? (
     userInfo ? (
       <div className="DesktopSectionPanel__notifs">
         <span className="checkboxLabel">
           Notify me when new sections are added:
         </span>
-        <CourseCheckBox
-          course={course}
-          checked={checked}
-          userInfo={userInfo}
-          fetchUserInfo={fetchUserInfo}
+        <CourseCheckBox checked={checked} onCheckboxClick={onCheckboxClick} />
+        <SignUpModal
+          visible={showModal}
+          onCancel={() => setShowModal(false)}
+          onSignIn={onSignIn}
+          onSuccess={() => setShowModal(false)}
+          defaultStep={Step.Failed}
         />
       </div>
     ) : (

--- a/components/notifications/modal/Failed.tsx
+++ b/components/notifications/modal/Failed.tsx
@@ -1,0 +1,31 @@
+import React, { ReactElement } from 'react';
+
+interface FailedProps {
+  onCancel: () => void;
+}
+
+export default function Failed({ onCancel }: FailedProps): ReactElement {
+  return (
+    <>
+      <div className="phone-modal__body">
+        <span className="phone-modal__header">
+          Oops! Something went wrong. Please try again later.
+        </span>
+      </div>
+      <div className="phone-modal__footer phone-modal__footer--buttons">
+        <div className="phone-modal__input-group">
+          <button key="cancel" onClick={onCancel} className="phone-modal__btn">
+            Exit
+          </button>
+          <button
+            key="ok"
+            onClick={onCancel}
+            className="phone-modal__btn phone-modal__btn--primary"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/notifications/modal/SignUpModal.tsx
+++ b/components/notifications/modal/SignUpModal.tsx
@@ -10,6 +10,7 @@ import macros from '../../macros';
 import Modal from '../../Modal';
 import PhoneNumber from './PhoneNumber';
 import VerificationCode from './VerificationCode';
+import Failed from './Failed';
 
 const VERIFICATION_CODE_LENGTH = 6;
 
@@ -18,14 +19,16 @@ interface SignUpModalProps {
   onCancel: () => void;
   onSignIn: (token: string) => void;
   onSuccess: () => void;
+  defaultStep?: Step;
 }
 
 /**
  * A step in the sign-up process associated with a modal screen.
  */
-enum Step {
+export enum Step {
   PhoneNumber,
   VerificationCode,
+  Failed,
 }
 
 export default function SignUpModal({
@@ -33,8 +36,9 @@ export default function SignUpModal({
   onCancel,
   onSignIn,
   onSuccess,
+  defaultStep,
 }: SignUpModalProps): ReactElement {
-  const [step, setStep] = useState<Step>(Step.PhoneNumber);
+  const [step, setStep] = useState<Step>(defaultStep || Step.PhoneNumber);
   const [phoneNumber, setPhoneNumber] = useState('');
   const [verificationCode, setVerificationCode] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -156,6 +160,8 @@ export default function SignUpModal({
                   error={statusMessage}
                 />
               );
+            case Step.Failed:
+              return <Failed onCancel={onCancel} />;
             default:
               return <></>;
           }

--- a/components/panels/CourseCheckBox.tsx
+++ b/components/panels/CourseCheckBox.tsx
@@ -5,53 +5,21 @@
 
 import { uniqueId } from 'lodash';
 import React, { ReactElement, useState } from 'react';
-import IconCheckMark from '../icons/IconCheckmark';
 import Tooltip, { TooltipDirection } from '../Tooltip';
-import Keys from '../Keys';
-import macros from '../macros';
 import { Course } from '../types';
-import axios from 'axios';
+
 import { UserInfo } from '../../components/types';
 
 type CourseCheckBoxProps = {
-  course: Course;
   checked: boolean;
-  userInfo: UserInfo;
-  fetchUserInfo: () => void;
+  onCheckboxClick: () => void;
 };
 
 export default function CourseCheckBox({
-  course,
   checked,
-  userInfo,
-  fetchUserInfo,
+  onCheckboxClick,
 }: CourseCheckBoxProps): ReactElement {
   const [notifSwitchId] = useState(uniqueId('notifSwitch-'));
-
-  function onCheckboxClick(): void {
-    if (checked) {
-      axios
-        .delete(
-          `${process.env.NEXT_PUBLIC_NOTIFS_ENDPOINT}/user/subscriptions`,
-          {
-            data: {
-              token: userInfo.token,
-              sectionIds: [],
-              courseIds: [Keys.getClassHash(course)],
-            },
-          }
-        )
-        .then(() => fetchUserInfo());
-    } else {
-      axios
-        .put(`${process.env.NEXT_PUBLIC_NOTIFS_ENDPOINT}/user/subscriptions`, {
-          token: userInfo.token,
-          sectionIds: [],
-          courseIds: [Keys.getClassHash(course)],
-        })
-        .then(() => fetchUserInfo());
-    }
-  }
 
   return (
     <div className="signUpSwitch">


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

Immediately flips the notifications toggle switch on click, reverting if the network request fails. Adds a popup to indicate a network failure.

# Tickets

###### A link to any tickets this PR is associated with on Trello.

[Frontend Notifications - Visual toggle](https://trello.com/c/7wLN1Rcs/247-frontend-notifications-visual-toggle)

# Contributors

###### Anyone who contributed to this PR for future reference.

@koulopoulos 

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Move request logic from `<CourseCheckBox/>` component to `<SignUpForNotifications/>` in order to handle and update checked status accordingly.
- Update `<SignUpModal/>` component to include Failure state.

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

- Maybe consider a specific message/design for the failure popup.

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [x] Is passing tsc
- [x] Is passing existing tests
- [x] Has documentation and comments in code
- [ ] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
