### PR TITLE
Sort Section Search Results by Subscription then Open Seat Count

### DIFF
--- a/components/ResultsPage/Results/CourseResult.tsx
+++ b/components/ResultsPage/Results/CourseResult.tsx
@@ -26,9 +26,7 @@ interface CourseResultProps {
 }
 
 const sortSections = (sections: Section[], userInfo?: UserInfo): Section[] => {
-  // NOTE (sam 2023-01-29): unsure why sections needs to be cloned, because all we're doing is sorting, nothing desctructive.
-  // also unsure why sections are memoized after being sorted (in CourseResult)
-  // memoized based on current course, but course should never change over lifetime of a CourseResult
+  // TODO (sam 2023-03-09): remove this `cloneDeep` call once we can remove the `useMemo` from `CourseResult`.
   const sortedSections = cloneDeep(sections);
   const subscribedSectionIds = new Set(userInfo?.sectionIds ?? []);
   sortedSections.sort((a: Section, b: Section) => {
@@ -57,6 +55,7 @@ export function CourseResult({
   const router = useRouter();
   const termId = router.query.termId as string;
   const campus = router.query.campus as string;
+  // TODO (sam 2023-03-09): this is necessary because of `useShowAll`, which should likely not be coupled to courses.
   const sortedSections = useMemo(
     () => sortSections(course.sections, userInfo),
     [course]

--- a/components/ResultsPage/Results/CourseResult.tsx
+++ b/components/ResultsPage/Results/CourseResult.tsx
@@ -30,7 +30,7 @@ const sortSections = (sections: Section[], userInfo?: UserInfo): Section[] => {
   // also unsure why sections are memoized after being sorted (in CourseResult)
   // memoized based on current course, but course should never change over lifetime of a CourseResult
   const sortedSections = cloneDeep(sections);
-  const subscribedSectionIds = new Set(userInfo.sectionIds ?? []);
+  const subscribedSectionIds = new Set(userInfo?.sectionIds ?? []);
   sortedSections.sort((a: Section, b: Section) => {
     const aHash = Keys.getSectionHash(a);
     const bHash = Keys.getSectionHash(b);

--- a/components/ResultsPage/Results/CourseResult.tsx
+++ b/components/ResultsPage/Results/CourseResult.tsx
@@ -17,6 +17,7 @@ import { DesktopSectionPanel, MobileSectionPanel } from './SectionPanel';
 import useResultDetail from './useResultDetail';
 import useShowAll from './useShowAll';
 import { MobileSearchResult, SearchResult } from './SearchResult';
+import Keys from '../../Keys';
 interface CourseResultProps {
   course: Course;
   userInfo: UserInfo;
@@ -24,17 +25,25 @@ interface CourseResultProps {
   fetchUserInfo: () => void;
 }
 
-const sortSections = (sections: Section[]): Section[] => {
+const sortSections = (sections: Section[], userInfo: UserInfo): Section[] => {
+  // NOTE (sam 2023-01-29): unsure why sections needs to be cloned, because all we're doing is sorting, nothing desctructive.
+  // also unsure why sections are memoized after being sorted (in CourseResult)
+  // memoized based on current course, but course should never change over lifetime of a CourseResult
   const sortedSections = cloneDeep(sections);
+  const subscribedSectionIds = new Set(userInfo.sectionIds);
   sortedSections.sort((a: Section, b: Section) => {
-    if (!a.profs || !a.profs[0]) {
+    const aHash = Keys.getSectionHash(a);
+    const bHash = Keys.getSectionHash(b);
+    if (subscribedSectionIds.has(aHash) === subscribedSectionIds.has(bHash)) {
+      if (a.seatsRemaining === b.seatsRemaining) {
+        return b.waitRemaining - a.waitRemaining;
+      }
+      return b.seatsRemaining - a.seatsRemaining;
+    } else if (subscribedSectionIds.has(aHash)) {
       return -1;
+    } else {
+      return 1;
     }
-    if (!b.profs || !b.profs[0]) return 1;
-
-    if (a.profs[0] === b.profs[0]) return 0;
-
-    return a.profs[0] < b.profs[0] ? -1 : 1;
   });
   return sortedSections;
 };
@@ -48,7 +57,10 @@ export function CourseResult({
   const router = useRouter();
   const termId = router.query.termId as string;
   const campus = router.query.campus as string;
-  const sortedSections = useMemo(() => sortSections(course.sections), [course]);
+  const sortedSections = useMemo(
+    () => sortSections(course.sections, userInfo),
+    [course]
+  );
   const { optionalDisplay } = useResultDetail(course);
 
   const { showAll, setShowAll, renderedSections, hideShowAll } = useShowAll(

--- a/components/ResultsPage/Results/CourseResult.tsx
+++ b/components/ResultsPage/Results/CourseResult.tsx
@@ -213,7 +213,10 @@ export function MobileCourseResult({
   const [showNUPath, setShowNUPath] = useState(false);
   const [showPrereq, setShowPrereq] = useState(false);
   const [showCoreq, setShowCoreq] = useState(false);
-  const sortedSections = useMemo(() => sortSections(course.sections), [course]);
+  const sortedSections = useMemo(
+    () => sortSections(course.sections, userInfo),
+    [course]
+  );
   const { showAll, setShowAll, renderedSections, hideShowAll } = useShowAll(
     sortedSections
   );

--- a/components/ResultsPage/Results/CourseResult.tsx
+++ b/components/ResultsPage/Results/CourseResult.tsx
@@ -25,12 +25,12 @@ interface CourseResultProps {
   fetchUserInfo: () => void;
 }
 
-const sortSections = (sections: Section[], userInfo: UserInfo): Section[] => {
+const sortSections = (sections: Section[], userInfo?: UserInfo): Section[] => {
   // NOTE (sam 2023-01-29): unsure why sections needs to be cloned, because all we're doing is sorting, nothing desctructive.
   // also unsure why sections are memoized after being sorted (in CourseResult)
   // memoized based on current course, but course should never change over lifetime of a CourseResult
   const sortedSections = cloneDeep(sections);
-  const subscribedSectionIds = new Set(userInfo.sectionIds);
+  const subscribedSectionIds = new Set(userInfo.sectionIds ?? []);
   sortedSections.sort((a: Section, b: Section) => {
     const aHash = Keys.getSectionHash(a);
     const bHash = Keys.getSectionHash(b);


### PR DESCRIPTION


# Purpose

Currently, sections are sorted by professor names. It might be more helpful for users to sort by subscription and open seat count.

<br>

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- https://trello.com/c/6ULqeoqP

# Contributors

###### Anyone who contributed to this PR for future reference.

- @soulwa 
- @hankewyczz 

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- replace `sortSections` with a sort by subscription status, then remaining section seats, then remaining waitlist seats in `CourseResult.tsx`, have it take `userInfo` as necessary context for sorting by subscription.

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [ ] Is passing linting checks
- [ ] Is passing tsc
- [ ] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
