### PR TITLE
prevent 100% width with inline-block

### DIFF
--- a/styles/_FilterPills.scss
+++ b/styles/_FilterPills.scss
@@ -29,6 +29,7 @@
     padding: 0 10px;
     line-height: 30px;
     background: rgba(255, 255, 255, 0);
+    display: inline-block;
   }
 
   &__clear:hover {


### PR DESCRIPTION
# Purpose
"Clear All" button on the search results page has 100% width. Want the clickable area to be around the actual button.
<br>

# Tickets
- n/a

# Contributors
- @pranavphadke1 

# Feature List
-  Prevented this with 'display: inline-block'

# Notes
 - n/a
<br>
# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [ ] Is passing linting checks
- [ ] Is passing tsc
- [ ] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

Primary Reviewer: @Lucas-Dunker 
Secondary: @allychao @soulwa 

<br>
@sandboxnu/searchneu

