### PR TITLE
Remove TotalResultsDisplay and CSS

### DIFF
--- a/components/ResultsPage/useSearch.ts
+++ b/components/ResultsPage/useSearch.ts
@@ -101,7 +101,6 @@ export default function useSearch({
 
   const returnedData = data && {
     filterOptions: data[0].filterOptions,
-    totalCount: data[0].totalCount,
     results: data.map((d) => d.results).flat(),
     hasNextPage: data[0].hasNextPage,
   };
@@ -118,7 +117,6 @@ function transformGraphQLToSearchResult(
 ): SearchResult {
   const transformedResults: SearchResult = {
     results: [],
-    totalCount: graphqlResults.search.totalCount,
     filterOptions: graphqlResults.search.filterOptions as FilterOptions,
     hasNextPage: graphqlResults.search.pageInfo.hasNextPage,
   };

--- a/components/tests/integration/testData/SearchResultsGQL.json
+++ b/components/tests/integration/testData/SearchResultsGQL.json
@@ -1,6 +1,5 @@
 {
   "search": {
-    "totalCount": 10000,
     "pageInfo": {
       "hasNextPage": true
     },

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -325,9 +325,6 @@ exports[`should render a section 1`] = `
           </div>
           <div className=\\"Results_SidebarSpacer\\" />
           <div className=\\"Results_Main\\">
-            <div className=\\"Results_Aggregation\\">
-              <TotalResultsDisplay />
-            </div>
             <LoadingContainer>
               <div style={{...}} />
             </LoadingContainer>

--- a/components/types.ts
+++ b/components/types.ts
@@ -109,7 +109,6 @@ export enum MeetingType {
 // Represents the course and employee data returned by /search
 export interface SearchResult {
   results: SearchItem[];
-  totalCount: number;
   filterOptions: FilterOptions;
   hasNextPage: boolean;
 }
@@ -125,7 +124,6 @@ export type SearchItem = CourseResult | Employee;
 export function BLANK_SEARCH_RESULT(): SearchResult {
   return {
     results: [],
-    totalCount: 0,
     filterOptions: {
       nupath: [],
       subject: [],

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -177,7 +177,6 @@ export type SearchResultItem = ClassOccurrence | Employee;
 
 export type SearchResultItemConnection = {
   __typename?: 'SearchResultItemConnection';
-  totalCount: Scalars['Int'];
   pageInfo: PageInfo;
   nodes?: Maybe<Array<Maybe<SearchResultItem>>>;
   filterOptions: FilterOptions;
@@ -294,115 +293,112 @@ export type SearchResultsQueryVariables = Exact<{
 
 export type SearchResultsQuery = { __typename?: 'Query' } & {
   search?: Maybe<
-    { __typename?: 'SearchResultItemConnection' } & Pick<
-      SearchResultItemConnection,
-      'totalCount'
-    > & {
-        pageInfo: { __typename?: 'PageInfo' } & Pick<PageInfo, 'hasNextPage'>;
-        filterOptions: { __typename?: 'FilterOptions' } & {
-          nupath?: Maybe<
-            Array<
-              { __typename?: 'FilterAgg' } & Pick<
-                FilterAgg,
-                'value' | 'count' | 'description'
-              >
-            >
-          >;
-          subject?: Maybe<
-            Array<
-              { __typename?: 'FilterAgg' } & Pick<
-                FilterAgg,
-                'value' | 'count' | 'description'
-              >
-            >
-          >;
-          classType?: Maybe<
-            Array<
-              { __typename?: 'FilterAgg' } & Pick<
-                FilterAgg,
-                'value' | 'count' | 'description'
-              >
-            >
-          >;
-          campus?: Maybe<
-            Array<
-              { __typename?: 'FilterAgg' } & Pick<
-                FilterAgg,
-                'value' | 'count' | 'description'
-              >
-            >
-          >;
-          honors?: Maybe<
-            Array<
-              { __typename?: 'FilterAgg' } & Pick<
-                FilterAgg,
-                'value' | 'count' | 'description'
-              >
-            >
-          >;
-        };
-        nodes?: Maybe<
+    { __typename?: 'SearchResultItemConnection' } & {
+      pageInfo: { __typename?: 'PageInfo' } & Pick<PageInfo, 'hasNextPage'>;
+      filterOptions: { __typename?: 'FilterOptions' } & {
+        nupath?: Maybe<
           Array<
-            Maybe<
-              | ({ __typename?: 'ClassOccurrence' } & Pick<
-                  ClassOccurrence,
-                  | 'name'
-                  | 'subject'
-                  | 'classId'
-                  | 'termId'
-                  | 'host'
-                  | 'desc'
-                  | 'nupath'
-                  | 'prereqs'
-                  | 'coreqs'
-                  | 'prereqsFor'
-                  | 'optPrereqsFor'
-                  | 'maxCredits'
-                  | 'minCredits'
-                  | 'classAttributes'
-                  | 'url'
-                  | 'prettyUrl'
-                  | 'lastUpdateTime'
-                  | 'feeAmount'
-                  | 'feeDescription'
-                > & { type: 'ClassOccurrence' } & {
-                    sections: Array<
-                      { __typename?: 'Section' } & Pick<
-                        Section,
-                        | 'campus'
-                        | 'classId'
-                        | 'classType'
-                        | 'crn'
-                        | 'honors'
-                        | 'host'
-                        | 'lastUpdateTime'
-                        | 'meetings'
-                        | 'profs'
-                        | 'seatsCapacity'
-                        | 'seatsRemaining'
-                        | 'subject'
-                        | 'termId'
-                        | 'url'
-                        | 'waitCapacity'
-                        | 'waitRemaining'
-                      >
-                    >;
-                  })
-              | ({ __typename?: 'Employee' } & Pick<
-                  Employee,
-                  | 'email'
-                  | 'firstName'
-                  | 'lastName'
-                  | 'name'
-                  | 'officeRoom'
-                  | 'phone'
-                  | 'primaryDepartment'
-                  | 'primaryRole'
-                > & { type: 'Employee' })
+            { __typename?: 'FilterAgg' } & Pick<
+              FilterAgg,
+              'value' | 'count' | 'description'
             >
           >
         >;
-      }
+        subject?: Maybe<
+          Array<
+            { __typename?: 'FilterAgg' } & Pick<
+              FilterAgg,
+              'value' | 'count' | 'description'
+            >
+          >
+        >;
+        classType?: Maybe<
+          Array<
+            { __typename?: 'FilterAgg' } & Pick<
+              FilterAgg,
+              'value' | 'count' | 'description'
+            >
+          >
+        >;
+        campus?: Maybe<
+          Array<
+            { __typename?: 'FilterAgg' } & Pick<
+              FilterAgg,
+              'value' | 'count' | 'description'
+            >
+          >
+        >;
+        honors?: Maybe<
+          Array<
+            { __typename?: 'FilterAgg' } & Pick<
+              FilterAgg,
+              'value' | 'count' | 'description'
+            >
+          >
+        >;
+      };
+      nodes?: Maybe<
+        Array<
+          Maybe<
+            | ({ __typename?: 'ClassOccurrence' } & Pick<
+                ClassOccurrence,
+                | 'name'
+                | 'subject'
+                | 'classId'
+                | 'termId'
+                | 'host'
+                | 'desc'
+                | 'nupath'
+                | 'prereqs'
+                | 'coreqs'
+                | 'prereqsFor'
+                | 'optPrereqsFor'
+                | 'maxCredits'
+                | 'minCredits'
+                | 'classAttributes'
+                | 'url'
+                | 'prettyUrl'
+                | 'lastUpdateTime'
+                | 'feeAmount'
+                | 'feeDescription'
+              > & { type: 'ClassOccurrence' } & {
+                  sections: Array<
+                    { __typename?: 'Section' } & Pick<
+                      Section,
+                      | 'campus'
+                      | 'classId'
+                      | 'classType'
+                      | 'crn'
+                      | 'honors'
+                      | 'host'
+                      | 'lastUpdateTime'
+                      | 'meetings'
+                      | 'profs'
+                      | 'seatsCapacity'
+                      | 'seatsRemaining'
+                      | 'subject'
+                      | 'termId'
+                      | 'url'
+                      | 'waitCapacity'
+                      | 'waitRemaining'
+                    >
+                  >;
+                })
+            | ({ __typename?: 'Employee' } & Pick<
+                Employee,
+                | 'email'
+                | 'firstName'
+                | 'lastName'
+                | 'name'
+                | 'officeRoom'
+                | 'phone'
+                | 'primaryDepartment'
+                | 'primaryRole'
+              > & { type: 'Employee' })
+          >
+        >
+      >;
+    }
   >;
 };
 
@@ -524,7 +520,6 @@ export const SearchResultsDocument = gql`
       classType: $classType
       classIdRange: $classIdRange
     ) {
-      totalCount
       pageInfo {
         hasNextPage
       }

--- a/pages/[campus]/[termId]/search/[query].tsx
+++ b/pages/[campus]/[termId]/search/[query].tsx
@@ -106,30 +106,6 @@ export default function Results(): ReactElement | null {
     }`;
   };
 
-  const TotalResultsDisplay = (): ReactElement => {
-    // This has to be a null safe because searchData can be undefined on mount
-    const totalResults = searchData?.totalCount;
-    if (totalResults === undefined) {
-      // if it is undefined, dont render results
-      return <></>;
-    }
-    // our ES index has a cap of 10,000 results for any search regardless of
-    // pagination. Therefore, if we get the max, we add a + to indicate possibly more.
-    let totalResultsStr = '';
-    switch (totalResults) {
-      case 1:
-        totalResultsStr = ' result';
-        break;
-      case 10000:
-        totalResultsStr = '+ results';
-        break;
-      default:
-        totalResultsStr = ' results';
-        break;
-    }
-    return <p>{totalResults.toLocaleString('en-US') + totalResultsStr}</p>;
-  };
-
   return (
     <>
       <div>
@@ -158,17 +134,10 @@ export default function Results(): ReactElement | null {
           )}
 
           <div className="Results_Main">
-            {filtersAreSet ? (
+            {filtersAreSet && (
               <>
                 <FilterPills filters={filters} setFilters={setQParams} />
-                <div className="Results_Aggregation__withFilters">
-                  <TotalResultsDisplay />
-                </div>
               </>
-            ) : (
-              <div className="Results_Aggregation">
-                <TotalResultsDisplay />
-              </div>
             )}
             {!searchData ? (
               <LoadingContainer />

--- a/pages/api/searchResult.graphql
+++ b/pages/api/searchResult.graphql
@@ -22,7 +22,6 @@ query searchResults(
     classType: $classType
     classIdRange: $classIdRange
   ) {
-    totalCount
     pageInfo {
       hasNextPage
     }

--- a/styles/pages/_Results.scss
+++ b/styles/pages/_Results.scss
@@ -154,19 +154,6 @@ $SIDEBAR_WIDTH: 268px;
   font-size: inherit !important;
 }
 
-.Results_Aggregation {
-  font-style: italic;
-  font-family: Lato;
-  text-align: right;
-  padding-right: 14px;
-  margin-bottom: -7px;
-
-  &__withFilters {
-    @extend .Results_Aggregation;
-    margin-top: -22px;
-  }
-}
-
 .Breadcrumb_Container {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
# Purpose
We decided to remove the total results count from results page as it isn't accurate when performing filtering options.

<br>

# Tickets
- n/a

# Contributors
- @pranavphadke1 

# Feature List
- removed the function for calculating total results
- removed the function's usage
- removed relevant css

(Updated) Primary Reviewer: @Lucas-Dunker @hankewyczz 
Secondary: @soulwa 

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [ ] Is passing linting checks
- [ ] Is passing tsc
- [ ] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
