### PR TITLE
NULL Ticket Hotfix

### DIFF
--- a/components/ResultsPage/ResultsLoader.tsx
+++ b/components/ResultsPage/ResultsLoader.tsx
@@ -119,7 +119,7 @@ function ResultsLoader({
               (result) =>
                 result !== null &&
                 result !== undefined &&
-                result.class.subject !== 'NULL'
+                result?.class?.subject !== 'NULL'
             )
             .map((result) => {
               return (


### PR DESCRIPTION
# Purpose

In a previous ticket removing NULL course results, we forgot to make sure that course results are actually defined before checking their properties. This leads to a full site crash when a search query doesn't have any matches.

# Contributors
@Lucas-Dunker 

# Feature List
-Hotfix for null course filtering

# Pictures
![image](https://github.com/sandboxnu/searchneu/assets/93111430/4f9118f9-b6fc-4698-bd79-eb64051b3f0b)


# Reviewers
This is an emergency hotfix, so no reviewing this time!
