### PR TITLE
Disallow Empty Feedback

### DIFF
--- a/components/FeedbackModal.tsx
+++ b/components/FeedbackModal.tsx
@@ -3,7 +3,7 @@
  * See the license file in the root folder for details.
  */
 
-import React from 'react';
+import React, { ReactElement, useState } from 'react';
 import { Transition } from 'react-transition-group';
 
 import {
@@ -36,37 +36,32 @@ type Props = {
   feedbackModalOpen: boolean;
 };
 
-class FeedbackModal extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
+export function FeedbackModal(props: Props): ReactElement {
+  const [messageValue, setMessageValue] = useState('');
+  const [contactValue, setContactValue] = useState('');
+  const [sending, setSending] = useState(false);
+  const [messageVisible, setMessageVisible] = useState(false);
+  const [showError, setShowError] = useState(false);
 
-    this.state = {
-      messageValue: '',
-      contactValue: '',
-      sending: false,
-      messageVisible: false,
-    };
+  const onSubmit = async () => {
+    setSending(true);
 
-    this.onTextAreaChange = this.onTextAreaChange.bind(this);
-    this.onContactChange = this.onContactChange.bind(this);
-    this.hideMessage = this.hideMessage.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
-  }
+    if (!messageValue) {
+      setSending(false);
+      setShowError(true);
+      return;
+    }
 
-  async onSubmit() {
-    this.setState({
-      sending: true,
-    });
     // Send an event to amplitude too, just for redundancy.
     macros.logAmplitudeEvent('Feedback', {
-      text: this.state.messageValue,
-      contact: this.state.contactValue,
+      text: messageValue,
+      contact: contactValue,
     });
 
     await axios
       .post(`${process.env.NEXT_PUBLIC_NOTIFS_ENDPOINT}/feedback`, {
-        contact: this.state.contactValue,
-        message: this.state.messageValue,
+        contact: contactValue,
+        message: messageValue,
       })
       .catch((error) => {
         macros.error('Unable to submit feedback', error);
@@ -75,120 +70,116 @@ class FeedbackModal extends React.Component<Props, State> {
         );
       });
 
-    this.setState({
-      sending: false,
-      messageVisible: true,
-      messageValue: '',
-      contactValue: '',
-    });
+    setSending(false);
+    setMessageVisible(true);
+    setMessageValue('');
+    setContactValue('');
+    setShowError(false);
 
     // Hide the message after 2 seconds
     setTimeout(() => {
-      this.setState({
-        messageVisible: false,
-      });
+      setMessageVisible(false);
     }, 2000);
 
-    this.props.toggleForm();
-  }
+    props.toggleForm();
+  };
 
-  onTextAreaChange(event) {
-    this.setState({
-      messageValue: event.target.value,
-    });
-  }
+  const onTextAreaChange = (event) => {
+    setMessageValue(event.target.value);
+  };
 
-  onContactChange(event) {
-    this.setState({
-      contactValue: event.target.value,
-    });
-  }
+  const onContactChange = (event) => {
+    setContactValue(event.target.value);
+  };
 
-  hideMessage() {
-    this.setState({
-      messageVisible: false,
-    });
-  }
+  const hideMessage = () => {
+    setMessageVisible(false);
+  };
 
-  render() {
-    const transitionStyles = {
-      entering: { opacity: 1 },
-      entered: { opacity: 1 },
-      exited: { display: 'none', opacity: 0 },
-    };
+  const transitionStyles = {
+    entering: { opacity: 1 },
+    entered: { opacity: 1 },
+    exited: { display: 'none', opacity: 0 },
+  };
 
-    const firstText =
-      "Find a bug in Search NEU? Find a query that doesn't come up with the results you were looking for? Have an idea for an improvement or just want to say hi? Drop a line below! Feel free to write whatever you want to and someone on the team will read it.";
-    const secondBody = [
-      <p key="0">
-        By default this form is anonymous. Leave your name and/or email if you
-        want us to be able to contact you.
-      </p>,
-      <Input
-        name="contact"
-        form="feedbackForm"
-        className="formModalInput"
-        onChange={this.onContactChange}
-        key="1"
-      />,
-    ];
+  const firstText =
+    "Find a bug in Search NEU? Find a query that doesn't come up with the results you were looking for? Have an idea for an improvement or just want to say hi? Drop a line below! Feel free to write whatever you want to and someone on the team will read it.";
 
-    const header = 'Search NEU Contact Form';
+  const secondBody = [
+    <p key="0">
+      By default this form is anonymous. Leave your name and/or email if you
+      want us to be able to contact you.
+    </p>,
+    <Input
+      name="contact"
+      form="feedbackForm"
+      className="formModalInput"
+      onChange={onContactChange}
+      key="1"
+    />,
+  ];
 
-    return (
-      <div className="feedback-container">
-        <Transition in={this.state.messageVisible} timeout={500}>
-          {(state) => {
-            return (
-              <Message
-                success
-                className="alertMessage"
-                header="Your submission was successful."
-                style={{ ...transitionStyles[state] }}
-                onDismiss={this.hideMessage}
-              />
-            );
-          }}
-        </Transition>
-        <Modal
-          open={this.props.feedbackModalOpen}
-          onClose={this.props.toggleForm}
-          size="small"
-          className="feedback-modal-container"
-        >
-          <Header icon="mail" content={header} />
-          <Modal.Content className="formModalContent">
-            <Form>
-              <div className="feedbackParagraph">{firstText}</div>
-              <TextArea
-                name="response"
-                form="feedbackForm"
-                className="feedbackTextbox"
-                onChange={this.onTextAreaChange}
-              />
-              {secondBody}
-            </Form>
-          </Modal.Content>
-          <Modal.Actions>
-            <Button basic color="red" onClick={this.props.toggleForm}>
-              <Icon name="remove" />
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              color="green"
+  const header = 'Search NEU Contact Form';
+
+  return (
+    <div className="feedback-container">
+      <Transition in={messageVisible} timeout={500}>
+        {(state) => {
+          return (
+            <Message
+              success
+              className="alertMessage"
+              header="Your submission was successful."
+              style={{ ...transitionStyles[state] }}
+              onDismiss={hideMessage}
+            />
+          );
+        }}
+      </Transition>
+      <Modal
+        open={props.feedbackModalOpen}
+        onClose={props.toggleForm}
+        size="small"
+        className="feedback-modal-container"
+      >
+        <Header icon="mail" content={header} />
+        {showError ? (
+          <Header color="red" content="Can't submit empty message!" />
+        ) : (
+          <></>
+        )}
+        <Header color="red" />
+        <Modal.Content className="formModalContent">
+          <Form>
+            <div className="feedbackParagraph">{firstText}</div>
+            <TextArea
+              name="response"
               form="feedbackForm"
-              onClick={this.onSubmit}
-              disabled={this.state.sending}
-            >
-              <Icon name="checkmark" />
-              {this.state.sending ? 'Sending...' : 'Submit'}
-            </Button>
-          </Modal.Actions>
-        </Modal>
-      </div>
-    );
-  }
+              className="feedbackTextbox"
+              onChange={onTextAreaChange}
+            />
+            {secondBody}
+          </Form>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button basic color="red" onClick={props.toggleForm}>
+            <Icon name="remove" />
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            color="green"
+            form="feedbackForm"
+            onClick={onSubmit}
+            disabled={sending}
+          >
+            <Icon name="checkmark" />
+            {sending ? 'Sending...' : 'Submit'}
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    </div>
+  );
 }
 
 export default FeedbackModal;

--- a/components/FeedbackModal.tsx
+++ b/components/FeedbackModal.tsx
@@ -51,7 +51,8 @@ export function FeedbackModal(props: Props): ReactElement {
   const onSubmit = async () => {
     setSending(true);
 
-    if (!messageValue) {
+    // does the message not contain any alphanumeric characters (A-Z,0-9,_)
+    if (!/\w/.test(messageValue)) {
       setSending(false);
       setShowError(true);
       return;

--- a/components/FeedbackModal.tsx
+++ b/components/FeedbackModal.tsx
@@ -144,11 +144,10 @@ export function FeedbackModal(props: Props): ReactElement {
       >
         <Header icon="mail" content={header} />
         {showError ? (
-          <Header color="red" content="Can't submit empty message!" />
+          <Message color="red" content="Can't submit an empty message!" />
         ) : (
           <></>
         )}
-        <Header color="red" />
         <Modal.Content className="formModalContent">
           <Form>
             <div className="feedbackParagraph">{firstText}</div>

--- a/components/FeedbackModal.tsx
+++ b/components/FeedbackModal.tsx
@@ -3,7 +3,7 @@
  * See the license file in the root folder for details.
  */
 
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { Transition } from 'react-transition-group';
 
 import {
@@ -42,6 +42,11 @@ export function FeedbackModal(props: Props): ReactElement {
   const [sending, setSending] = useState(false);
   const [messageVisible, setMessageVisible] = useState(false);
   const [showError, setShowError] = useState(false);
+
+  // when form is toggled, error message should not be shown.
+  useEffect(() => {
+    setShowError(false);
+  }, [props.feedbackModalOpen]);
 
   const onSubmit = async () => {
     setSending(true);

--- a/components/tests/__snapshots__/FeedbackModal.test.js.snap
+++ b/components/tests/__snapshots__/FeedbackModal.test.js.snap
@@ -12,11 +12,11 @@ exports[`should render form is closed 1`] = `
         <div className=\\"feedbackParagraph\\">
           Find a bug in Search NEU? Find a query that doesn&#39;t come up with the results you were looking for? Have an idea for an improvement or just want to say hi? Drop a line below! Feel free to write whatever you want to and someone on the team will read it.
         </div>
-        <TextArea name=\\"response\\" form=\\"feedbackForm\\" className=\\"feedbackTextbox\\" onChange={[Function: bound onTextAreaChange]} as=\\"textarea\\" rows={3} />
+        <TextArea name=\\"response\\" form=\\"feedbackForm\\" className=\\"feedbackTextbox\\" onChange={[Function: onTextAreaChange]} as=\\"textarea\\" rows={3} />
         <p>
           By default this form is anonymous. Leave your name and/or email if you want us to be able to contact you.
         </p>
-        <Input name=\\"contact\\" form=\\"feedbackForm\\" className=\\"formModalInput\\" onChange={[Function: bound onContactChange]} type=\\"text\\" />
+        <Input name=\\"contact\\" form=\\"feedbackForm\\" className=\\"formModalInput\\" onChange={[Function: onContactChange]} type=\\"text\\" />
       </Form>
     </ModalContent>
     <ModalActions>
@@ -24,7 +24,7 @@ exports[`should render form is closed 1`] = `
         <Icon name=\\"remove\\" as=\\"i\\" />
         Cancel
       </Button>
-      <Button type=\\"submit\\" color=\\"green\\" form=\\"feedbackForm\\" onClick={[Function: bound onSubmit]} disabled={false} as=\\"button\\">
+      <Button type=\\"submit\\" color=\\"green\\" form=\\"feedbackForm\\" onClick={[Function: onSubmit]} disabled={false} as=\\"button\\">
         <Icon name=\\"checkmark\\" as=\\"i\\" />
         Submit
       </Button>
@@ -45,11 +45,11 @@ exports[`should render the form 1`] = `
         <div className=\\"feedbackParagraph\\">
           Find a bug in Search NEU? Find a query that doesn&#39;t come up with the results you were looking for? Have an idea for an improvement or just want to say hi? Drop a line below! Feel free to write whatever you want to and someone on the team will read it.
         </div>
-        <TextArea name=\\"response\\" form=\\"feedbackForm\\" className=\\"feedbackTextbox\\" onChange={[Function: bound onTextAreaChange]} as=\\"textarea\\" rows={3} />
+        <TextArea name=\\"response\\" form=\\"feedbackForm\\" className=\\"feedbackTextbox\\" onChange={[Function: onTextAreaChange]} as=\\"textarea\\" rows={3} />
         <p>
           By default this form is anonymous. Leave your name and/or email if you want us to be able to contact you.
         </p>
-        <Input name=\\"contact\\" form=\\"feedbackForm\\" className=\\"formModalInput\\" onChange={[Function: bound onContactChange]} type=\\"text\\" />
+        <Input name=\\"contact\\" form=\\"feedbackForm\\" className=\\"formModalInput\\" onChange={[Function: onContactChange]} type=\\"text\\" />
       </Form>
     </ModalContent>
     <ModalActions>
@@ -57,7 +57,7 @@ exports[`should render the form 1`] = `
         <Icon name=\\"remove\\" as=\\"i\\" />
         Cancel
       </Button>
-      <Button type=\\"submit\\" color=\\"green\\" form=\\"feedbackForm\\" onClick={[Function: bound onSubmit]} disabled={false} as=\\"button\\">
+      <Button type=\\"submit\\" color=\\"green\\" form=\\"feedbackForm\\" onClick={[Function: onSubmit]} disabled={false} as=\\"button\\">
         <Icon name=\\"checkmark\\" as=\\"i\\" />
         Submit
       </Button>

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -380,7 +380,7 @@ exports[`should render a section 1`] = `
               <FeedbackModal toggleForm={[Function: toggleModal]} feedbackModalOpen={false}>
                 <div className=\\"feedback-container\\">
                   <Transition in={false} timeout={500} mountOnEnter={false} unmountOnExit={false} appear={false} enter={true} exit={true} onEnter={[Function: noop]} onEntering={[Function: noop]} onEntered={[Function: noop]} onExit={[Function: noop]} onExiting={[Function: noop]} onExited={[Function: noop]}>
-                    <Message success={true} className=\\"alertMessage\\" header=\\"Your submission was successful.\\" style={{...}} onDismiss={[Function: bound hideMessage]}>
+                    <Message success={true} className=\\"alertMessage\\" header=\\"Your submission was successful.\\" style={{...}} onDismiss={[Function: hideMessage]}>
                       <div style={{...}} className=\\"ui success message alertMessage\\">
                         <Icon name=\\"close\\" onClick={[Function (anonymous)]} as=\\"i\\">
                           <i onClick={[Function (anonymous)]} aria-hidden=\\"true\\" className=\\"close icon\\" />


### PR DESCRIPTION
# Purpose
Currently we get a lot of empty feedback responses in #searchneu-support. This PR doesn't let you submit the form if there is empty feedback.

# Tickets

https://trello.com/c/d62GYY7r/401-feedback-form-shouldnt-allow-an-empty-response

# Contributors

@sebwittr 

# Feature List

- Changed the Feedback Modal from a Class Component to a Functional Component.
- Within `onSubmit` added a check to see if message value is empty.
- Added an error banner to the component if the message is empty.

# Pictures

<img width="719" alt="Screenshot 2023-10-29 at 4 15 55 PM" src="https://github.com/sandboxnu/searchneu/assets/79394243/7e0dc235-3b5c-4532-8b34-ddb2af493b76">

# Reviewers

**Primary**: @Lucas-Dunker  @pranavphadke1 

**Secondary**: @ananyaspatil 
