### PR TITLE
Fix Missing "Prerequisites For"

### DIFF
--- a/components/ClassPage/ClassPageReqsBody.tsx
+++ b/components/ClassPage/ClassPageReqsBody.tsx
@@ -99,18 +99,16 @@ export default function ClassPageReqsBody({
           }
           className="prereqsFor"
           body={
-            latestOccurrence.prereqsFor.values.length === 0 ? (
+            latestOccurrence.prereqsFor.length === 0 ? (
               <span className="noReqs">None</span>
             ) : (
               <div
                 className={`reqItemsContainer ${
-                  latestOccurrence.prereqsFor.values.length > 3
-                    ? 'showScroll'
-                    : ''
+                  latestOccurrence.prereqsFor.length > 3 ? 'showScroll' : ''
                 }`}
               >
                 <div className="reqItemsScroll">
-                  {latestOccurrence.prereqsFor.values.map((value) => {
+                  {latestOccurrence.prereqsFor.map((value) => {
                     return (
                       <div
                         className="reqItem"


### PR DESCRIPTION
# Purpose

This fixes #229. I think the prereq/coreq access logic got copied when prereqFor has a different data format (flat list of classes).

# Tickets

N/A >:)

# Pictures
**Before: [link to prod](https://searchneu.com/NEU/202430/classPage/CS/2500)**
<img width="400" alt="before-change" src="https://github.com/sandboxnu/searchneu/assets/2746893/ce62c69c-b0c1-487b-b842-784b9a99554a">

**After: [link to staging!](https://searchneu-git-luke-prereq-for-fix-sandboxneu.vercel.app/NEU/202430/classPage/CS/2500)**
<img width="400" alt="after-change" src="https://github.com/sandboxnu/searchneu/assets/2746893/10022151-f2c2-497e-8304-85fec2829151">

# Reviewers
@Lucas-Dunker 
