### PR TITLE
Pp/robert findings visual 10/4/23 bugs

### DIFF
--- a/components/panels/CourseCheckBox.tsx
+++ b/components/panels/CourseCheckBox.tsx
@@ -5,10 +5,8 @@
 
 import { uniqueId } from 'lodash';
 import React, { ReactElement, useState } from 'react';
-import IconCheckMark from '../icons/IconCheckmark';
 import Tooltip, { TooltipDirection } from '../Tooltip';
 import Keys from '../Keys';
-import macros from '../macros';
 import { Course } from '../types';
 import axios from 'axios';
 import { UserInfo } from '../../components/types';
@@ -59,12 +57,16 @@ export default function CourseCheckBox({
         <input
           checked={checked}
           onChange={onCheckboxClick}
-          className="notif-switch-checkbox"
+          className="react-switch-checkbox"
           id={notifSwitchId}
           type="checkbox"
         />
-        <label className="notif-switch-label" htmlFor={notifSwitchId}>
-          <span className="notif-switch-button" />
+        <label
+          className="react-switch-label"
+          style={{ marginTop: '0px' }}
+          htmlFor={notifSwitchId}
+        >
+          <span className="react-switch-button" />
         </label>
       </div>
       <Tooltip

--- a/components/panels/SectionCheckBox.tsx
+++ b/components/panels/SectionCheckBox.tsx
@@ -75,12 +75,16 @@ export default function SectionCheckBox({
         <input
           checked={checked}
           onChange={onCheckboxClick}
-          className="notif-switch-checkbox"
+          className="react-switch-checkbox"
           id={notifSwitchId}
           type="checkbox"
         />
-        <label className="notif-switch-label" htmlFor={notifSwitchId}>
-          <span className="notif-switch-button" />
+        <label
+          className="react-switch-label"
+          style={{ marginTop: '0px' }}
+          htmlFor={notifSwitchId}
+        >
+          <span className="react-switch-button" />
         </label>
       </div>
       <Tooltip

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -324,85 +324,87 @@ exports[`should render a section 1`] = `
             </FilterPanel>
           </div>
           <div className=\\"Results_SidebarSpacer\\" />
-          <div className=\\"Results_Main\\">
-            <LoadingContainer>
-              <div style={{...}} />
-            </LoadingContainer>
-            <Memo(Footer)>
-              <div className=\\"footer\\">
-                <div className=\\"footer ui basic center aligned segment\\">
-                  Interested in how SearchNEU works? Check out our
-                  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://docs.searchneu.com/\\">
-                     documentation!
-                  </a>
+          <div className=\\"Results_MainWrapper\\">
+            <div className=\\"Results_Main\\">
+              <LoadingContainer>
+                <div style={{...}} />
+              </LoadingContainer>
+              <Memo(Footer)>
+                <div className=\\"footer\\">
+                  <div className=\\"footer ui basic center aligned segment\\">
+                    Interested in how SearchNEU works? Check out our
+                    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://docs.searchneu.com/\\">
+                       documentation!
+                    </a>
+                  </div>
+                  <div className=\\"ui divider\\" />
+                  <div className=\\"footer ui basic center aligned segment\\">
+                    See an issue or want to add to this website? Fork it or create an issue on
+                    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu\\">
+                       GitHub
+                    </a>
+                    .
+                  </div>
+                  <div className=\\"ui divider\\" />
+                  <div className=\\"footer ui basic center aligned segment credits\\">
+                    A 
+                    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://www.sandboxneu.com\\">
+                      Sandbox
+                    </a>
+                     Project (founded by 
+                    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"http://github.com/ryanhugh\\">
+                      Ryan Hughes
+                    </a>
+                    , with some awesome 
+                    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu/graphs/contributors\\">
+                      contributors
+                    </a>
+                    )
+                  </div>
+                  <div className=\\"footer ui basic center aligned segment affiliation\\">
+                    Search NEU is built for students by students &amp; is not affiliated with NEU.
+                  </div>
+                  <div className=\\"footer ui basic center aligned segment contact\\">
+                    <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
+                      Feedback
+                    </a>
+                     • 
+                    <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
+                      Report a bug
+                    </a>
+                     • 
+                    <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
+                      Contact
+                    </a>
+                  </div>
                 </div>
-                <div className=\\"ui divider\\" />
-                <div className=\\"footer ui basic center aligned segment\\">
-                  See an issue or want to add to this website? Fork it or create an issue on
-                  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu\\">
-                     GitHub
-                  </a>
-                  .
-                </div>
-                <div className=\\"ui divider\\" />
-                <div className=\\"footer ui basic center aligned segment credits\\">
-                  A 
-                  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://www.sandboxneu.com\\">
-                    Sandbox
-                  </a>
-                   Project (founded by 
-                  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"http://github.com/ryanhugh\\">
-                    Ryan Hughes
-                  </a>
-                  , with some awesome 
-                  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu/graphs/contributors\\">
-                    contributors
-                  </a>
-                  )
-                </div>
-                <div className=\\"footer ui basic center aligned segment affiliation\\">
-                  Search NEU is built for students by students &amp; is not affiliated with NEU.
-                </div>
-                <div className=\\"footer ui basic center aligned segment contact\\">
-                  <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
-                    Feedback
-                  </a>
-                   • 
-                  <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
-                    Report a bug
-                  </a>
-                   • 
-                  <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
-                    Contact
-                  </a>
-                </div>
-              </div>
-              <FeedbackModal toggleForm={[Function: toggleModal]} feedbackModalOpen={false}>
-                <div className=\\"feedback-container\\">
-                  <Transition in={false} timeout={500} mountOnEnter={false} unmountOnExit={false} appear={false} enter={true} exit={true} onEnter={[Function: noop]} onEntering={[Function: noop]} onEntered={[Function: noop]} onExit={[Function: noop]} onExiting={[Function: noop]} onExited={[Function: noop]}>
-                    <Message success={true} className=\\"alertMessage\\" header=\\"Your submission was successful.\\" style={{...}} onDismiss={[Function: hideMessage]}>
-                      <div style={{...}} className=\\"ui success message alertMessage\\">
-                        <Icon name=\\"close\\" onClick={[Function (anonymous)]} as=\\"i\\">
-                          <i onClick={[Function (anonymous)]} aria-hidden=\\"true\\" className=\\"close icon\\" />
-                        </Icon>
-                        <MessageContent>
-                          <div className=\\"content\\">
-                            <MessageHeader content=\\"Your submission was successful.\\">
-                              <div className=\\"header\\">
-                                Your submission was successful.
-                              </div>
-                            </MessageHeader>
-                          </div>
-                        </MessageContent>
-                      </div>
-                    </Message>
-                  </Transition>
-                  <Modal open={false} onClose={[Function: toggleModal]} size=\\"small\\" className=\\"feedback-modal-container\\" centered={true} dimmer={true} closeOnDimmerClick={true} closeOnDocumentClick={false} eventPool=\\"Modal\\">
-                    <Portal closeOnDocumentClick={false} trigger={[undefined]} eventPool=\\"Modal\\" mountNode={{...}} open={false} onClose={[Function (anonymous)]} onMount={[Function (anonymous)]} onOpen={[Function (anonymous)]} onUnmount={[Function (anonymous)]} closeOnEscape={true} openOnTriggerClick={true} />
-                  </Modal>
-                </div>
-              </FeedbackModal>
-            </Memo(Footer)>
+                <FeedbackModal toggleForm={[Function: toggleModal]} feedbackModalOpen={false}>
+                  <div className=\\"feedback-container\\">
+                    <Transition in={false} timeout={500} mountOnEnter={false} unmountOnExit={false} appear={false} enter={true} exit={true} onEnter={[Function: noop]} onEntering={[Function: noop]} onEntered={[Function: noop]} onExit={[Function: noop]} onExiting={[Function: noop]} onExited={[Function: noop]}>
+                      <Message success={true} className=\\"alertMessage\\" header=\\"Your submission was successful.\\" style={{...}} onDismiss={[Function: hideMessage]}>
+                        <div style={{...}} className=\\"ui success message alertMessage\\">
+                          <Icon name=\\"close\\" onClick={[Function (anonymous)]} as=\\"i\\">
+                            <i onClick={[Function (anonymous)]} aria-hidden=\\"true\\" className=\\"close icon\\" />
+                          </Icon>
+                          <MessageContent>
+                            <div className=\\"content\\">
+                              <MessageHeader content=\\"Your submission was successful.\\">
+                                <div className=\\"header\\">
+                                  Your submission was successful.
+                                </div>
+                              </MessageHeader>
+                            </div>
+                          </MessageContent>
+                        </div>
+                      </Message>
+                    </Transition>
+                    <Modal open={false} onClose={[Function: toggleModal]} size=\\"small\\" className=\\"feedback-modal-container\\" centered={true} dimmer={true} closeOnDimmerClick={true} closeOnDocumentClick={false} eventPool=\\"Modal\\">
+                      <Portal closeOnDocumentClick={false} trigger={[undefined]} eventPool=\\"Modal\\" mountNode={{...}} open={false} onClose={[Function (anonymous)]} onMount={[Function (anonymous)]} onOpen={[Function (anonymous)]} onUnmount={[Function (anonymous)]} closeOnEscape={true} openOnTriggerClick={true} />
+                    </Modal>
+                  </div>
+                </FeedbackModal>
+              </Memo(Footer)>
+            </div>
           </div>
         </div>
         <div className=\\"botttomPadding\\" />

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -324,85 +324,87 @@ exports[`should render a section 1`] = `
             </FilterPanel>
           </div>
           <div className=\\"Results_SidebarSpacer\\" />
-          <div className=\\"Results_Main\\">
-            <LoadingContainer>
-              <div style={{...}} />
-            </LoadingContainer>
-            <Memo(Footer)>
-              <div className=\\"footer\\">
-                <div className=\\"footer ui basic center aligned segment\\">
-                  Interested in how SearchNEU works? Check out our
-                  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://docs.searchneu.com/\\">
-                     documentation!
-                  </a>
+          <div className=\\"Results_MainWrapper\\">
+            <div className=\\"Results_Main\\">
+              <LoadingContainer>
+                <div style={{...}} />
+              </LoadingContainer>
+              <Memo(Footer)>
+                <div className=\\"footer\\">
+                  <div className=\\"footer ui basic center aligned segment\\">
+                    Interested in how SearchNEU works? Check out our
+                    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://docs.searchneu.com/\\">
+                       documentation!
+                    </a>
+                  </div>
+                  <div className=\\"ui divider\\" />
+                  <div className=\\"footer ui basic center aligned segment\\">
+                    See an issue or want to add to this website? Fork it or create an issue on
+                    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu\\">
+                       GitHub
+                    </a>
+                    .
+                  </div>
+                  <div className=\\"ui divider\\" />
+                  <div className=\\"footer ui basic center aligned segment credits\\">
+                    A 
+                    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://www.sandboxneu.com\\">
+                      Sandbox
+                    </a>
+                     Project (founded by 
+                    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"http://github.com/ryanhugh\\">
+                      Ryan Hughes
+                    </a>
+                    , with some awesome 
+                    <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu/graphs/contributors\\">
+                      contributors
+                    </a>
+                    )
+                  </div>
+                  <div className=\\"footer ui basic center aligned segment affiliation\\">
+                    Search NEU is built for students by students &amp; is not affiliated with NEU.
+                  </div>
+                  <div className=\\"footer ui basic center aligned segment contact\\">
+                    <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
+                      Feedback
+                    </a>
+                     • 
+                    <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
+                      Report a bug
+                    </a>
+                     • 
+                    <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
+                      Contact
+                    </a>
+                  </div>
                 </div>
-                <div className=\\"ui divider\\" />
-                <div className=\\"footer ui basic center aligned segment\\">
-                  See an issue or want to add to this website? Fork it or create an issue on
-                  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu\\">
-                     GitHub
-                  </a>
-                  .
-                </div>
-                <div className=\\"ui divider\\" />
-                <div className=\\"footer ui basic center aligned segment credits\\">
-                  A 
-                  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://www.sandboxneu.com\\">
-                    Sandbox
-                  </a>
-                   Project (founded by 
-                  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"http://github.com/ryanhugh\\">
-                    Ryan Hughes
-                  </a>
-                  , with some awesome 
-                  <a target=\\"_blank\\" rel=\\"noopener noreferrer\\" href=\\"https://github.com/sandboxnu/searchneu/graphs/contributors\\">
-                    contributors
-                  </a>
-                  )
-                </div>
-                <div className=\\"footer ui basic center aligned segment affiliation\\">
-                  Search NEU is built for students by students &amp; is not affiliated with NEU.
-                </div>
-                <div className=\\"footer ui basic center aligned segment contact\\">
-                  <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
-                    Feedback
-                  </a>
-                   • 
-                  <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
-                    Report a bug
-                  </a>
-                   • 
-                  <a role=\\"button\\" tabIndex={0} onClick={[Function: toggleModal]}>
-                    Contact
-                  </a>
-                </div>
-              </div>
-              <FeedbackModal toggleForm={[Function: toggleModal]} feedbackModalOpen={false}>
-                <div className=\\"feedback-container\\">
-                  <Transition in={false} timeout={500} mountOnEnter={false} unmountOnExit={false} appear={false} enter={true} exit={true} onEnter={[Function: noop]} onEntering={[Function: noop]} onEntered={[Function: noop]} onExit={[Function: noop]} onExiting={[Function: noop]} onExited={[Function: noop]}>
-                    <Message success={true} className=\\"alertMessage\\" header=\\"Your submission was successful.\\" style={{...}} onDismiss={[Function: bound hideMessage]}>
-                      <div style={{...}} className=\\"ui success message alertMessage\\">
-                        <Icon name=\\"close\\" onClick={[Function (anonymous)]} as=\\"i\\">
-                          <i onClick={[Function (anonymous)]} aria-hidden=\\"true\\" className=\\"close icon\\" />
-                        </Icon>
-                        <MessageContent>
-                          <div className=\\"content\\">
-                            <MessageHeader content=\\"Your submission was successful.\\">
-                              <div className=\\"header\\">
-                                Your submission was successful.
-                              </div>
-                            </MessageHeader>
-                          </div>
-                        </MessageContent>
-                      </div>
-                    </Message>
-                  </Transition>
-                  <Modal open={false} onClose={[Function: toggleModal]} size=\\"small\\" className=\\"feedback-modal-container\\" centered={true} dimmer={true} closeOnDimmerClick={true} closeOnDocumentClick={false} eventPool=\\"Modal\\">
-                    <Portal closeOnDocumentClick={false} trigger={[undefined]} eventPool=\\"Modal\\" mountNode={{...}} open={false} onClose={[Function (anonymous)]} onMount={[Function (anonymous)]} onOpen={[Function (anonymous)]} onUnmount={[Function (anonymous)]} closeOnEscape={true} openOnTriggerClick={true} />
-                  </Modal>
-                </div>
-              </FeedbackModal>
-            </Memo(Footer)>
+                <FeedbackModal toggleForm={[Function: toggleModal]} feedbackModalOpen={false}>
+                  <div className=\\"feedback-container\\">
+                    <Transition in={false} timeout={500} mountOnEnter={false} unmountOnExit={false} appear={false} enter={true} exit={true} onEnter={[Function: noop]} onEntering={[Function: noop]} onEntered={[Function: noop]} onExit={[Function: noop]} onExiting={[Function: noop]} onExited={[Function: noop]}>
+                      <Message success={true} className=\\"alertMessage\\" header=\\"Your submission was successful.\\" style={{...}} onDismiss={[Function: bound hideMessage]}>
+                        <div style={{...}} className=\\"ui success message alertMessage\\">
+                          <Icon name=\\"close\\" onClick={[Function (anonymous)]} as=\\"i\\">
+                            <i onClick={[Function (anonymous)]} aria-hidden=\\"true\\" className=\\"close icon\\" />
+                          </Icon>
+                          <MessageContent>
+                            <div className=\\"content\\">
+                              <MessageHeader content=\\"Your submission was successful.\\">
+                                <div className=\\"header\\">
+                                  Your submission was successful.
+                                </div>
+                              </MessageHeader>
+                            </div>
+                          </MessageContent>
+                        </div>
+                      </Message>
+                    </Transition>
+                    <Modal open={false} onClose={[Function: toggleModal]} size=\\"small\\" className=\\"feedback-modal-container\\" centered={true} dimmer={true} closeOnDimmerClick={true} closeOnDocumentClick={false} eventPool=\\"Modal\\">
+                      <Portal closeOnDocumentClick={false} trigger={[undefined]} eventPool=\\"Modal\\" mountNode={{...}} open={false} onClose={[Function (anonymous)]} onMount={[Function (anonymous)]} onOpen={[Function (anonymous)]} onUnmount={[Function (anonymous)]} closeOnEscape={true} openOnTriggerClick={true} />
+                    </Modal>
+                  </div>
+                </FeedbackModal>
+              </Memo(Footer)>
+            </div>
           </div>
         </div>
         <div className=\\"botttomPadding\\" />

--- a/pages/[campus]/[termId]/search/[query].tsx
+++ b/pages/[campus]/[termId]/search/[query].tsx
@@ -133,31 +133,33 @@ export default function Results(): ReactElement | null {
             </>
           )}
 
-          <div className="Results_Main">
-            {filtersAreSet && (
-              <>
-                <FilterPills filters={filters} setFilters={setQParams} />
-              </>
-            )}
-            {!searchData ? (
-              <LoadingContainer />
-            ) : searchData && searchData.results.length === 0 ? (
-              <EmptyResultsContainer
-                query={query}
-                filtersAreSet={filtersAreSet}
-                setFilters={setQParams}
-              />
-            ) : (
-              <ResultsLoader
-                results={searchData.results}
-                loadMore={loadMore}
-                hasNextPage={searchData.hasNextPage}
-                userInfo={userInfo}
-                onSignIn={onSignIn}
-                fetchUserInfo={fetchUserInfo}
-              />
-            )}
-            <Footer />
+          <div className="Results_MainWrapper">
+            <div className="Results_Main">
+              {filtersAreSet && (
+                <>
+                  <FilterPills filters={filters} setFilters={setQParams} />
+                </>
+              )}
+              {!searchData ? (
+                <LoadingContainer />
+              ) : searchData && searchData.results.length === 0 ? (
+                <EmptyResultsContainer
+                  query={query}
+                  filtersAreSet={filtersAreSet}
+                  setFilters={setQParams}
+                />
+              ) : (
+                <ResultsLoader
+                  results={searchData.results}
+                  loadMore={loadMore}
+                  hasNextPage={searchData.hasNextPage}
+                  userInfo={userInfo}
+                  onSignIn={onSignIn}
+                  fetchUserInfo={fetchUserInfo}
+                />
+              )}
+              <Footer />
+            </div>
           </div>
         </div>
         <div className="botttomPadding" />

--- a/styles/_DropdownFilter.scss
+++ b/styles/_DropdownFilter.scss
@@ -79,18 +79,15 @@
     transition-duration: 0.5s;
     transition-property: transform;
     transform: rotate(0deg);
-    transform-origin: top center;
 
     &:hover {
       cursor: pointer;
     }
 
     &.expanded {
-      top: 16px;
       transition-duration: 0.5s;
       transition-property: transform;
       transform: rotate(180deg);
-      transform-origin: top center;
     }
 
     &.disabled {

--- a/styles/_Modal.scss
+++ b/styles/_Modal.scss
@@ -7,7 +7,8 @@
   height: 100vh;
   width: 100vw;
   z-index: 999999;
-  background: Colors.$Light_Grey;
+  // This is Colors.Light_Grey with alpha value of 0.7
+  background-color: #d1d3d7b3;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/styles/_Modal.scss
+++ b/styles/_Modal.scss
@@ -7,8 +7,7 @@
   height: 100vh;
   width: 100vw;
   z-index: 999999;
-  // This is Colors.Light_Grey with alpha value of 0.7
-  background-color: #d1d3d7b3;
+  background-color: Colors.$Light_Grey_Transparent;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/styles/_SearchBar.scss
+++ b/styles/_SearchBar.scss
@@ -6,7 +6,7 @@
   display: flex;
   align-items: stretch;
   border: 1px solid Colors.$Light_Grey;
-  border-radius: 10px;
+  border-radius: 5px;
   width: 100%;
 
   &:focus-within {
@@ -33,7 +33,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 0 9px 9px 0;
+    border-radius: 0 4px 4px 0;
     width: 50px;
     cursor: pointer;
 

--- a/styles/_SearchBar.scss
+++ b/styles/_SearchBar.scss
@@ -35,6 +35,7 @@
     justify-content: center;
     border-radius: 0 4px 4px 0;
     width: 50px;
+    margin: -1px;
     cursor: pointer;
 
     &:focus {

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -27,3 +27,7 @@ $Light_Grey: #d1d3d7;
 $Green: #1f8b2a;
 $Light_Green: #a9dfae;
 $Light_Blue: #b5cad8;
+
+// Transparent Background
+// This is Colors.Light_Grey with alpha value of 0.7
+$Light_Grey_Transparent: #d1d3d7b3;

--- a/styles/pages/_Results.scss
+++ b/styles/pages/_Results.scss
@@ -202,7 +202,7 @@ $SIDEBAR_WIDTH: 268px;
   display: flex;
   flex: 1;
   text-align: right;
-  margin: 0 40px 0 30px;
+  margin: 0 17px 0 30px;
   position: relative;
   justify-content: flex-end;
 

--- a/styles/pages/_Results.scss
+++ b/styles/pages/_Results.scss
@@ -111,7 +111,7 @@ $SIDEBAR_WIDTH: 268px;
   }
 
   background-color: Colors.$Off_White;
-  padding: 25px 15px 25px 15px;
+  padding: 16px 15px 25px 15px;
 }
 
 .Results_SidebarSpacer {

--- a/styles/pages/_Results.scss
+++ b/styles/pages/_Results.scss
@@ -119,6 +119,12 @@ $SIDEBAR_WIDTH: 268px;
   flex-shrink: 0;
 }
 
+.Results_MainWrapper {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
 .Results_Main {
   padding-top: 10px;
   padding-right: 40px;

--- a/styles/results/_DesktopSectionPanel.scss
+++ b/styles/results/_DesktopSectionPanel.scss
@@ -114,4 +114,8 @@
       }
     }
   }
+  // If notifications present, last td should't have a right border
+  > td:last-child {
+    border-right: 0px;
+  }
 }


### PR DESCRIPTION
# Purpose

This addresses several visual bugs @robertkkan2 documented [here](https://www.notion.so/sandboxnu/Visual-Bugs-Robert-Findings-10-4-23-a9d36c5200f3488b95c6d9755912d500)

# Tickets

https://trello.com/c/uqMlXlbe

# Contributors

@pranavphadke1 

# Feature List
- Removed the "double border" to the right of notifications cell in the sections table
- Switched toggles to use same styling as the honors classes toggle (this has additional tech debt I want to address later)
- Centered search results body on larger screens
- Consistent right margin for user icon (when signed in with number). Made to match the left margin of the search logo
- Updated cornor radii of search bar to match the class cards
- Centered chevrons when uncollapsed (this needs future refinement --> possibly switching to a different chevron)
- Reduced top padding on filters wrapper to allign "Subject" to the title of first class card in search result
- Added alpha value (opacity) to the background of the notification sign up modal

# Reviewers

**Primary**:
@Lucas-Dunker @sebwittr 

**Secondary**:
@allychao @ananyaspatil 