### PR TITLE
Decreased margin-top to avoid text overlap with husky logo on mobile …

### DIFF
--- a/styles/home/_ExploratorySearchButton.scss
+++ b/styles/home/_ExploratorySearchButton.scss
@@ -14,7 +14,7 @@
 
   @media (max-width: 500px) {
     margin: 0px auto;
-    margin-top: 36px;
+    margin-top: 10px;
   }
 }
 


### PR DESCRIPTION
…display

# Purpose
Fixing visual bug on mobile display where the Homepage's link to view current semester classes overlaps with the SearchNEU logo. Just shifted link text upwards on screen so they no longer overlap.

# Tickets
https://trello.com/c/9rx81MeC

# Contributors
@ananyaspatil 

# Feature List
Decreased margin-top value in _ExploratorySearchButton.scss file to shift link text upwards on page.

# Reviewers
Primary reviewer:
@Lucas-Dunker 

Secondary reviewers:
@pranavphadke1 @sebwittr @allychao 
