### PR TITLE
Add ctrl+click to the "View more info for this class" button, remove "back to search results" url.

### DIFF
--- a/components/ClassPage/PageContent.tsx
+++ b/components/ClassPage/PageContent.tsx
@@ -23,8 +23,6 @@ export default function PageContent({
   classPageInfo,
   isCoreq,
 }: PageContentProps): ReactElement {
-  const router = useRouter();
-
   // TODO: hacky front-end solution because for some reason allOccurrences includes
   // termIds where there are no sections. This should probably be fixed on the backend.
   if (classPageInfo && classPageInfo.class) {
@@ -40,9 +38,7 @@ export default function PageContent({
           <span className="coreqHeaderCourse">{` ${subject}${classId}`}</span>
         </h2>
       ) : (
-        <div className="backToResults" onClick={() => router.back()}>
-          Back to Search Results
-        </div>
+        <></>
       )}
       {classPageInfo && classPageInfo.class && (
         <div className="classPageInfoContent">

--- a/components/ResultsPage/Results/CourseResult.tsx
+++ b/components/ResultsPage/Results/CourseResult.tsx
@@ -58,7 +58,7 @@ export function CourseResult({
   // TODO (sam 2023-03-09): this is necessary because of `useShowAll`, which should likely not be coupled to courses.
   const sortedSections = useMemo(
     () => sortSections(course.sections, userInfo),
-    [course]
+    [course.sections, userInfo]
   );
   const { optionalDisplay } = useResultDetail(course);
 
@@ -124,17 +124,14 @@ export function CourseResult({
               )}
             </div>
             <div className="SearchResult__panel--right">
-              <div
-                onClick={() =>
-                  router.push(
-                    `/${campus}/${termId}/classPage/${course.subject}/${course.classId}`
-                  )
-                }
-              >
-                <div className="view-more-info-container">
-                  <IconNotepad className="notepad-icon" />
+              <div className="view-more-info-container">
+                <IconNotepad className="notepad-icon" />
+                <a
+                  className="view-more-info-link"
+                  href={`/${campus}/${termId}/classPage/${course.subject}/${course.classId}`}
+                >
                   <span>View more info for this class</span>
-                </div>
+                </a>
               </div>
 
               <SignUpForNotifications

--- a/pages/[campus]/[termId]/classPage/[subject]/[classId].tsx
+++ b/pages/[campus]/[termId]/classPage/[subject]/[classId].tsx
@@ -29,26 +29,6 @@ export default function Page(): ReactElement {
     return `/${newCampus}/${t}/classPage/${subject}/${classId}${window.location.search}`;
   };
 
-  const loadClassPageInfo = async (): Promise<void> => {
-    const classPage = await gqlClient.getClassPageInfo({ subject, classId });
-    if ((subject || classId) && !classPage.class) {
-      router.push('/404');
-    }
-    // assume coreq values will never be nested
-    const coreqs: CourseReq[] = classPage.class
-      ? classPage.class.latestOccurrence.coreqs.values
-      : [];
-
-    const coreqInfoArray = await pMap(coreqs, async (coreqVal) => {
-      return await gqlClient.getClassPageInfo({
-        subject: coreqVal.subject,
-        classId: coreqVal.classId,
-      });
-    });
-    setClassPageInfo(classPage);
-    setCoreqInfo(coreqInfoArray);
-  };
-
   useEffect(() => {
     fetchUserInfo();
   }, []);
@@ -72,8 +52,32 @@ export default function Page(): ReactElement {
   };
 
   useEffect(() => {
+    const loadClassPageInfo = async (): Promise<void> => {
+      if (subject && classId) {
+        const classPage = await gqlClient.getClassPageInfo({
+          subject,
+          classId,
+        });
+        if ((subject || classId) && !classPage.class) {
+          router.push('/404');
+        }
+        // assume coreq values will never be nested
+        const coreqs: CourseReq[] = classPage.class
+          ? classPage.class.latestOccurrence.coreqs.values
+          : [];
+
+        const coreqInfoArray = await pMap(coreqs, async (coreqVal) => {
+          return await gqlClient.getClassPageInfo({
+            subject: coreqVal.subject,
+            classId: coreqVal.classId,
+          });
+        });
+        setClassPageInfo(classPage);
+        setCoreqInfo(coreqInfoArray);
+      }
+    };
     loadClassPageInfo();
-  }, [subject, classId]);
+  }, [subject, classId, router]);
 
   if (!termId || !campus) return null;
   return (

--- a/styles/results/_SearchResult.scss
+++ b/styles/results/_SearchResult.scss
@@ -64,6 +64,7 @@
         top: 24px;
         left: -10px;
         background: Colors.$Navy;
+
         & > div {
           border-color: transparent transparent Colors.$Navy transparent;
           left: 12px;
@@ -135,6 +136,7 @@
         margin-top: 10px;
         margin-bottom: 10px;
         cursor: pointer;
+
         &:hover {
           background: Colors.$Off_White;
         }
@@ -148,6 +150,11 @@
           line-height: 25px;
         }
       }
+
+      .view-more-info-link {
+        color: Colors.$Black;
+      }
+
       .notepad-icon {
         margin-right: 8px;
       }


### PR DESCRIPTION
# Purpose

This ticket turns the "View more info for this class' button into a url, allowing it to be more easily copied and ctrl-clicked. In the process, I found a bug related to graphql making queries before all the react data is loaded; a conditional has been added to wait for the necessary data to load before any data is fetched.

I also decided to remove the "back to search results" url, since I felt that it was unnecessary - other search engines like YouTube and Google don't have back buttons on their sites, they just rely on the browser. I can definitely roll this back if you think it's better to have it!

Feel free to check out the vercel deployment and see this change for yourself! 

# Tickets

[This ticket!](https://trello.com/c/pk772KOj/342-allow-ctrlclicking-of-class-pages)

# Contributors

@Lucas-Dunker 

# Pictures
![image](https://github.com/sandboxnu/searchneu/assets/93111430/69bf6288-059a-4462-9461-73285df92c0e)

![image](https://github.com/sandboxnu/searchneu/assets/93111430/988fe9b6-386b-4b4e-beaf-3f6b7a4e4657)

# Reviewers

**Primary**:
@pranavphadke1 

**Secondary**:
@sebwittr @ananyaspatil 
