### PR TITLE
fix applied filters overflow behavior on desktop

### DIFF
--- a/styles/_FilterPills.scss
+++ b/styles/_FilterPills.scss
@@ -71,10 +71,8 @@
       right: 50%;
       position: absolute;
       content: '';
-      width: 14px;
-      /* x size */
-      height: 1.5px;
-      /* x thickness */
+      width: 14px; /* x size */
+      height: 1.5px; /* x thickness */
       border-radius: 25px;
       background-color: Colors.$NEU_Red;
     }

--- a/styles/_FilterPills.scss
+++ b/styles/_FilterPills.scss
@@ -20,8 +20,14 @@
     padding-left: 0;
     padding-bottom: 0;
 
-    @media (max-width: 500px) {
+    // overflow behavior for mobile is a scrollbar (767px is max mobile horizontal width)
+    @media (max-width: 767px) {
       overflow-x: scroll;
+    }
+
+    // overflow behavior for desktop is stacking (768 is tablet and larger device width)
+    @media (min-width: 768px) {
+      flex-wrap: wrap;
     }
   }
 
@@ -65,8 +71,10 @@
       right: 50%;
       position: absolute;
       content: '';
-      width: 14px; /* x size */
-      height: 1.5px; /* x thickness */
+      width: 14px;
+      /* x size */
+      height: 1.5px;
+      /* x thickness */
       border-radius: 25px;
       background-color: Colors.$NEU_Red;
     }


### PR DESCRIPTION
# Purpose

Quick styling change to make sure applied filters stack in their flexbox instead of just overflowing off of the screen on desktop. Additionally, applied filters which overflow will be scrollable until `767px`, any larger device will observe the new stacking behavior.

# Tickets

https://trello.com/c/6eKA6SLP/224-filters-go-off-screen-when-too-many-are-added

# Contributors

@soulwa 

# Pictures
before:
<img width="1792" alt="Screenshot 2024-01-28 at 16 43 45" src="https://github.com/sandboxnu/searchneu/assets/20330404/272b0918-2344-4390-916a-d26c34e7bdaf">
after:
<img width="1792" alt="Screenshot 2024-01-28 at 16 44 35" src="https://github.com/sandboxnu/searchneu/assets/20330404/41b40a76-4d0f-4294-b26c-6605a83c1a49">

