### PR TITLE
Adapt course id filter slider to apply results right after drag

### DIFF
--- a/components/ResultsPage/RangeFilter.tsx
+++ b/components/ResultsPage/RangeFilter.tsx
@@ -31,7 +31,15 @@ export default function RangeFilter({
       <div className="RangeFilter__title">
         <p>{title}</p>
       </div>
-      <div className="RangeFilter__input">
+      <div
+        className="RangeFilter__input"
+        onClick={() =>
+          setActive({
+            min: controlledInput.min || courseIDs[0],
+            max: controlledInput.max || courseIDs[courseIDs.length - 1],
+          })
+        }
+      >
         <Slider
           range
           marks={marks}
@@ -52,19 +60,7 @@ export default function RangeFilter({
             controlledInput.max || courseIDs[courseIDs.length - 1],
           ]}
         />
-        <div
-          role="button"
-          tabIndex={0}
-          className="RangeFilter__apply-input"
-          onClick={() =>
-            setActive({
-              min: controlledInput.min || courseIDs[0],
-              max: controlledInput.max || courseIDs[courseIDs.length - 1],
-            })
-          }
-        >
-          <p>Apply</p>
-        </div>
+        <br></br>
       </div>
     </div>
   );

--- a/components/tests/integration/Result.test.jsx
+++ b/components/tests/integration/Result.test.jsx
@@ -147,8 +147,6 @@ describe.only('Results page integration tests', () => {
     // simulate clicking on slider value marks
     sliderMarks.at(1).simulate('click');
     sliderMarks.at(4).simulate('click');
-    // click the apply button
-    classIdRangeFilter.find('.RangeFilter__apply-input').simulate('click');
     expect(setQParams).toBeCalledWith({
       classIdRange: { max: 5000, min: 2000 },
     });

--- a/components/tests/integration/Result.test.jsx
+++ b/components/tests/integration/Result.test.jsx
@@ -142,11 +142,14 @@ describe.only('Results page integration tests', () => {
     const resultsPage = mount(<Results />);
     waitForComponentToPaint(resultsPage);
     const classIdRangeFilter = resultsPage.find('.RangeFilter');
+    const rangeFilterInput = resultsPage.find('.RangeFilter__input');
     // find all slider value marks
     const sliderMarks = classIdRangeFilter.find('.rc-slider-mark-text');
     // simulate clicking on slider value marks
     sliderMarks.at(1).simulate('click');
     sliderMarks.at(4).simulate('click');
+    // mouse leaves the slider
+    rangeFilterInput.simulate('click');
     expect(setQParams).toBeCalledWith({
       classIdRange: { max: 5000, min: 2000 },
     });

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`should render a section 1`] = `
                         Course ID Range
                       </p>
                     </div>
-                    <div className=\\"RangeFilter__input\\">
+                    <div className=\\"RangeFilter__input\\" onClick={[Function: onClick]}>
                       <Slider range={true} marks={{...}} allowCross={false} min={1000} max={8000} defaultValue={{...}} step={1000} onChange={[Function: onChange]} className=\\"RangeFilter__slider\\" value={{...}}>
                         <div className=\\"rc-slider RangeFilter__slider rc-slider-horizontal rc-slider-with-marks\\" style={[undefined]} onMouseDown={[Function: onSliderMouseDown]}>
                           <div className=\\"rc-slider-rail\\" style={{...}} />
@@ -312,11 +312,7 @@ exports[`should render a section 1`] = `
                           </Marks>
                         </div>
                       </Slider>
-                      <div role=\\"button\\" tabIndex={0} className=\\"RangeFilter__apply-input\\" onClick={[Function: onClick]}>
-                        <p>
-                          Apply
-                        </p>
-                      </div>
+                      <br />
                     </div>
                   </div>
                 </RangeFilter>


### PR DESCRIPTION
# Purpose

Removes the "apply" button under the slider and updates the course id ranges after the user has finished dragging the slider thumbs. Supports users dragging, and only applying once released.

# Tickets

https://trello.com/c/vQk2WCLn/349-course-id-filter-slider-onclick

# Contributors

@Anzhuo-W 

# Feature List

- Added onClick function to "range filter input", the outer div containing the slider. This updates the user's selected course ranges.
- Only updates when user is finished dragging because it is outside of the slider component itself.
- Removed button under slider that held logic to apply changes.
- Added a break to have some space between the slider and the bottom of the sidebar.
- Updated test to add click on the div containing slider.
- Updated test snapshot to remove apply button and reflect changes in components on the page.

# Pictures

https://github.com/sandboxnu/searchneu/assets/45926251/03b29c9a-5254-4acd-84b3-671f868bb9d6

# Reviewers

@pranavphadke1 
@sebwittr 