### PR TITLE
Remove zindex from boston background

### DIFF
--- a/styles/pages/_Home.scss
+++ b/styles/pages/_Home.scss
@@ -119,7 +119,6 @@
     bottom: 0;
     text-align: center;
     line-height: 0;
-    z-index: Indexes.$Four;
     pointer-events: none;
   }
 


### PR DESCRIPTION
# Purpose

The boston background covered the dropdown of terms, so this removes the zindex.


# Contributors
@sebwittr 

# Feature List

Remove zindex in _Home.scss
