### PR TITLE
Remove zindex from prod to fix merge conflict.

### DIFF
--- a/styles/pages/_Home.scss
+++ b/styles/pages/_Home.scss
@@ -119,7 +119,6 @@
     bottom: 0;
     text-align: center;
     line-height: 0;
-    z-index: Indexes.$Four;
     pointer-events: none;
   }
 


### PR DESCRIPTION
prod and master currently have different changes, and when merging them we're running into merge conflicts. In order to fix these conflicts we've merged prod into master. We need to also fix a single line in prod to remove a z-index bug that we already fixed.