### PR TITLE
Update _FeedbackModal.scss

### DIFF
--- a/styles/_FeedbackModal.scss
+++ b/styles/_FeedbackModal.scss
@@ -1,4 +1,5 @@
 @use 'variables' as Colors;
+@use 'zIndexes' as Indexes;
 
 .FeedbackModal {
   &__pill {
@@ -12,6 +13,7 @@
     border: 1px solid Colors.$Dark_Grey;
     border-radius: 20px;
     background: Colors.$White;
+    z-index: Indexes.$One;
 
     &:hover {
       cursor: pointer;
@@ -49,6 +51,7 @@
     background: Colors.$Off_White;
     box-shadow: 0 4px 6px Colors.$Light_Grey;
     border-radius: 3px;
+    z-index: Indexes.$One;
   }
 
   &__popoutHeader {


### PR DESCRIPTION
# Purpose

The feedback form didn't have a z-index value and would appear underneath parts of class cards

# Tickets

- https://trello.com/c/w4GONQtG

# Contributors
@pranavphadke1 

# Feature List

- Added z-index to feedback modal
-

# Pictures
Before:
<img width="330" alt="image" src="https://github.com/sandboxnu/searchneu/assets/91645231/65a201ba-dece-4c9e-957a-308fa9511c46">

After:
<img width="371" alt="image" src="https://github.com/sandboxnu/searchneu/assets/91645231/a8920084-6245-444c-a728-c974755fd220">

# Reviewers
**Primary**:
@sebwittr  @ananyaspatil 
