### PR TITLE
Adjust text inside meetings table

### DIFF
--- a/components/ResultsPage/Results/SectionPanel.tsx
+++ b/components/ResultsPage/Results/SectionPanel.tsx
@@ -192,7 +192,7 @@ export function DesktopSectionPanel({
         )}
       </td>
       <td>{section.campus}</td>
-      <td className="DeskopSectionPanel__seatcount">
+      <td>
         <div>
           <span className={'DesktopSectionPanel__' + getSeatsClass()}>
             {section.seatsRemaining}/{section.seatsCapacity}

--- a/components/ResultsPage/Results/SectionPanel.tsx
+++ b/components/ResultsPage/Results/SectionPanel.tsx
@@ -111,17 +111,25 @@ export function DesktopSectionPanel({
                 <span>
                   {meeting.type === MeetingType.FINAL_EXAM ? (
                     <>
-                      <b>Final Exam</b> |{' '}
-                      {`${time.start.format('h:mm')}-${time.end.format(
-                        'h:mm a'
-                      )} | ${meeting.location} | ${meeting.startDate.format(
-                        'MMM D'
-                      )}`}
+                      <div>
+                        <b>Final Exam</b> |{' '}
+                        {`${time.start.format('h:mm')}-${time.end.format(
+                          'h:mm a'
+                        )} `}
+                      </div>
+                      <div>
+                        {` ${meeting.location} | ${meeting.startDate.format(
+                          'MMM D'
+                        )}`}
+                      </div>
                     </>
                   ) : (
-                    `${time.start.format('h:mm')}-${time.end.format(
-                      'h:mm a'
-                    )} | ${meeting.location}`
+                    <>
+                      <div>
+                        {time.start.format('h:mm')}-{time.end.format('h:mm a')}
+                      </div>
+                      <div>{meeting.location}</div>
+                    </>
                   )}
                 </span>
                 <br />
@@ -184,8 +192,8 @@ export function DesktopSectionPanel({
         )}
       </td>
       <td>{section.campus}</td>
-      <td>
-        <div className="DeskopSectionPanel__seatcount">
+      <td className="DeskopSectionPanel__seatcount">
+        <div>
           <span className={'DesktopSectionPanel__' + getSeatsClass()}>
             {section.seatsRemaining}/{section.seatsCapacity}
           </span>

--- a/styles/results/_DesktopSectionPanel.scss
+++ b/styles/results/_DesktopSectionPanel.scss
@@ -20,7 +20,7 @@
       letter-spacing: 0.25px;
       display: inline-block;
       margin-bottom: 4px;
-      text-align: right;
+      text-align: left;
       width: max-content;
     }
   }
@@ -37,8 +37,14 @@
     }
   }
 
+  // Meetings
   > td:nth-child(3) {
     width: 35%;
+  }
+
+  // Notifications
+  > td:nth-child(6) {
+    width: 10%;
   }
 
   &__green {

--- a/styles/results/_WeekdayBoxes.scss
+++ b/styles/results/_WeekdayBoxes.scss
@@ -10,6 +10,7 @@
   font-size: 10px;
   line-height: 16px;
   text-align: center;
+  align-items: center;
 
   &__box {
     display: block;


### PR DESCRIPTION
# Purpose
- An existing issue with our section tables is that "final exam" schedule in the meetings column can sometimes be a really long line of text. This causes the width of the sections table to increase, sometimes increasing past the screen size. With our new notification changes, we always display the notifications column, making this bug more apparent.
- This PR puts some of the meeting text information on new lines to prevent the meetings column width from increasing too much

# Tickets
- No ticket, hotfix

# Contributors
@pranavphadke1 

# Feature List
- Modified how we display text for meeting information
- Added a fixed width to the Notification table so the text doesn't seem cramed

# Pictures

Old:
Long meeting text:
<img width="632" alt="image" src="https://github.com/sandboxnu/searchneu/assets/91645231/65842c00-87bf-4693-ab3b-15abb3a3c834">
Section table off screen:
<img width="1162" alt="image" src="https://github.com/sandboxnu/searchneu/assets/91645231/1ee462b1-b1bb-4649-8f5b-6dee3ae10749">


New:
New meeting text:
<img width="413" alt="image" src="https://github.com/sandboxnu/searchneu/assets/91645231/2907b946-a634-4eb1-88d6-1bde683e2cac">
Notification column slighly larger width:
<img width="157" alt="image" src="https://github.com/sandboxnu/searchneu/assets/91645231/722e8d42-743d-4725-9ab0-ecf059504824">



# Reviewers

**Primary**:
@sebwittr 

Secondary reviewers:
**Secondary**:
@robertkkan2 