### PR TITLE
Ap/total subscriptions limit

### DIFF
--- a/components/ResultsPage/Results/NotifSignUpButton.tsx
+++ b/components/ResultsPage/Results/NotifSignUpButton.tsx
@@ -13,14 +13,16 @@ export default function NotifSignUpButton({
     macros.logAmplitudeEvent('Notifs Button');
   };
 
-  const NOTIFICATIONS_ARE_DISABLED = true;
+  const NOTIFICATIONS_ARE_DISABLED = false;
 
   return (
     <button
       disabled={NOTIFICATIONS_ARE_DISABLED}
       onClick={onClickWithAmplitudeHook}
       type="button"
-      className={`Results_SignIn ${NOTIFICATIONS_ARE_DISABLED && 'disabledButton'}`}
+      className={`Results_SignIn ${
+        NOTIFICATIONS_ARE_DISABLED ? 'disabledButton' : ''
+      }`}
     >
       Sign In
     </button>

--- a/components/notifications/NewSubscriptionsLimitModal.tsx
+++ b/components/notifications/NewSubscriptionsLimitModal.tsx
@@ -1,0 +1,40 @@
+import React, { ReactElement } from 'react';
+import Modal from '../Modal';
+import X from '../icons/X.svg';
+import CryingHusky3 from '../icons/crying-husky-3.svg';
+
+interface DisabledNotificationsModalProps {
+  visible: boolean;
+  onCancel: () => void;
+}
+
+export default function DisabledNotificationsModal({
+  visible,
+  onCancel,
+}: DisabledNotificationsModalProps): ReactElement {
+  return (
+    <Modal visible={visible} onCancel={onCancel}>
+      <div className="phone-modal">
+        <div className="phone-modal__body">
+          <div className="phone-modal__action-btns">
+            <button
+              onClick={onCancel}
+              className="phone-modal__action-btn phone-modal__action-btn--x"
+            >
+              <X />
+            </button>
+          </div>
+          <CryingHusky3 />
+          <span className="phone-modal__header">
+            Notifications have paused for the summer
+          </span>
+
+          <span className="phone-modal__label">
+            Due to cost issues, we{`'`}re putting notifications on pause until
+            we acquire additional funding in the fall.
+          </span>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/components/notifications/NewSubscriptionsLimitModal.tsx
+++ b/components/notifications/NewSubscriptionsLimitModal.tsx
@@ -28,7 +28,7 @@ export default function NewSubscriptionsLimitModal({
           <span className="phone-modal__header">Notifications are up!</span>
 
           <span className="phone-modal__label">
-            We{`'`}re limiting users to 12 subscriptions per semester to keep
+            We{`'`}re limiting users to 12 subscriptions at a time to keep
             SearchNEU running for our growing NEU community.
           </span>
         </div>

--- a/components/notifications/NewSubscriptionsLimitModal.tsx
+++ b/components/notifications/NewSubscriptionsLimitModal.tsx
@@ -1,17 +1,17 @@
 import React, { ReactElement } from 'react';
 import Modal from '../Modal';
 import X from '../icons/X.svg';
-import CryingHusky3 from '../icons/crying-husky-3.svg';
+import Boston from '../icons/boston.svg';
 
-interface DisabledNotificationsModalProps {
+interface NewSubscriptionsLimitModalProps {
   visible: boolean;
   onCancel: () => void;
 }
 
-export default function DisabledNotificationsModal({
+export default function NewSubscriptionsLimitModal({
   visible,
   onCancel,
-}: DisabledNotificationsModalProps): ReactElement {
+}: NewSubscriptionsLimitModalProps): ReactElement {
   return (
     <Modal visible={visible} onCancel={onCancel}>
       <div className="phone-modal">
@@ -24,14 +24,12 @@ export default function DisabledNotificationsModal({
               <X />
             </button>
           </div>
-          <CryingHusky3 />
-          <span className="phone-modal__header">
-            Notifications have paused for the summer
-          </span>
+          <Boston />
+          <span className="phone-modal__header">Notifications are up!</span>
 
           <span className="phone-modal__label">
-            Due to cost issues, we{`'`}re putting notifications on pause until
-            we acquire additional funding in the fall.
+            We{`'`}re limiting users to 12 subscriptions per semester to keep
+            SearchNEU running for our growing NEU community.
           </span>
         </div>
       </div>

--- a/components/panels/CourseCheckBox.tsx
+++ b/components/panels/CourseCheckBox.tsx
@@ -85,7 +85,6 @@ export default function CourseCheckBox({
       <div className="signUpSwitch toggle">
         <div className="notifSwitch">
           <input
-            //disabled={NOTIFICATIONS_ARE_DISABLED && (userInfo.courseIds.length + userInfo.sectionIds.length >= NOTIFICATIONS_LIMIT)}
             disabled={notificationsLimitReached()}
             checked={checked}
             onChange={onCheckboxClick}

--- a/components/panels/CourseCheckBox.tsx
+++ b/components/panels/CourseCheckBox.tsx
@@ -27,7 +27,15 @@ export default function CourseCheckBox({
 }: CourseCheckBoxProps): ReactElement {
   const [showModal, setShowModal] = useState(false);
   const [notifSwitchId] = useState(uniqueId('notifSwitch-'));
-  const NOTIFICATIONS_ARE_DISABLED = true;
+
+  const NOTIFICATIONS_LIMIT = 12;
+  const NOTIFICATIONS_ARE_DISABLED = false;
+
+  const notificationsLimitReached = (): boolean =>
+    NOTIFICATIONS_ARE_DISABLED ||
+    (userInfo &&
+      userInfo.courseIds.length + userInfo.sectionIds.length >=
+        NOTIFICATIONS_LIMIT);
 
   const isCourseChecked = (): boolean =>
     userInfo && userInfo.courseIds.includes(Keys.getClassHash(course));
@@ -77,7 +85,8 @@ export default function CourseCheckBox({
       <div className="signUpSwitch toggle">
         <div className="notifSwitch">
           <input
-            disabled={NOTIFICATIONS_ARE_DISABLED}
+            //disabled={NOTIFICATIONS_ARE_DISABLED && (userInfo.courseIds.length + userInfo.sectionIds.length >= NOTIFICATIONS_LIMIT)}
+            disabled={notificationsLimitReached()}
             checked={checked}
             onChange={onCheckboxClick}
             className="react-switch-checkbox"
@@ -85,8 +94,14 @@ export default function CourseCheckBox({
             type="checkbox"
           />
           <label
-            className={`react-switch-label ${NOTIFICATIONS_ARE_DISABLED && 'disabledButton'}`}
-            style={{ marginTop: '0px', cursor: `${NOTIFICATIONS_ARE_DISABLED ? 'not-allowed' : 'inherit'}` }}
+            //className={`react-switch-label ${NOTIFICATIONS_ARE_DISABLED && 'disabledButton'}`}
+            className={`react-switch-label ${notificationsLimitReached()}`}
+            style={{
+              marginTop: '0px',
+              cursor: `${
+                notificationsLimitReached() ? 'not-allowed' : 'inherit'
+              }`,
+            }}
             htmlFor={notifSwitchId}
           >
             <span className="react-switch-button" />

--- a/components/panels/SectionCheckBox.tsx
+++ b/components/panels/SectionCheckBox.tsx
@@ -30,7 +30,14 @@ export default function SectionCheckBox({
   const [showModal, setShowModal] = useState(false);
   const [notifSwitchId] = useState(uniqueId('notifSwitch-'));
 
-  const NOTIFICATIONS_ARE_DISABLED = true;
+  const NOTIFICATIONS_LIMIT = 12;
+  const NOTIFICATIONS_ARE_DISABLED = false;
+
+  const notificationsLimitReached = (): boolean =>
+    NOTIFICATIONS_ARE_DISABLED ||
+    (userInfo &&
+      userInfo.courseIds.length + userInfo.sectionIds.length >=
+        NOTIFICATIONS_LIMIT);
 
   const isSectionChecked = (): boolean =>
     userInfo
@@ -98,7 +105,7 @@ export default function SectionCheckBox({
       <div className="signUpSwitch">
         <div className="notifSwitch">
           <input
-            disabled={NOTIFICATIONS_ARE_DISABLED}
+            disabled={notificationsLimitReached()}
             checked={checked}
             onChange={onCheckboxClick}
             className="react-switch-checkbox"
@@ -106,23 +113,32 @@ export default function SectionCheckBox({
             type="checkbox"
           />
           <label
-            className={`react-switch-label ${NOTIFICATIONS_ARE_DISABLED && 'disabledButton'}`}
-            style={{ marginTop: '0px', cursor: `${NOTIFICATIONS_ARE_DISABLED ? 'not-allowed' : 'inherit'}` }}
+            className={`react-switch-label ${
+              notificationsLimitReached() && 'disabledButton'
+            }`}
+            style={{
+              marginTop: '0px',
+              cursor: `${
+                notificationsLimitReached() ? 'not-allowed' : 'inherit'
+              }`,
+            }}
             htmlFor={notifSwitchId}
           >
             <span className="react-switch-button" />
           </label>
         </div>
-        {!NOTIFICATIONS_ARE_DISABLED && <Tooltip
-          text={
-            !userInfo
-              ? 'Sign in to subscribe for notifications.'
-              : checked
-              ? 'Unsubscribe from notifications for this section.'
-              : 'Subscribe to notifications for this section'
-          }
-          direction={TooltipDirection.Up}
-        />}
+        {!notificationsLimitReached() && (
+          <Tooltip
+            text={
+              !userInfo
+                ? 'Sign in to subscribe for notifications.'
+                : checked
+                ? 'Unsubscribe from notifications for this section.'
+                : 'Subscribe to notifications for this section'
+            }
+            direction={TooltipDirection.Up}
+          />
+        )}
       </div>
       <SignUpModal
         visible={showModal}

--- a/components/tests/pages/__snapshots__/Home.test.js.snap
+++ b/components/tests/pages/__snapshots__/Home.test.js.snap
@@ -20,7 +20,7 @@ exports[`should render a section 1`] = `
       <div className=\\"signInButtonContainer\\">
         <DropdownMenuWrapper userInfo={{...}} onSignIn={[Function: onSignIn]} onSignOut={[Function: onSignOut]} />
       </div>
-      <DisabledNotificationsModal visible={false} onCancel={[Function: onCancel]} />
+      <NewSubscriptionsLimitModal visible={false} onCancel={[Function: onCancel]} />
       <div>
         <div className=\\"ui center spacing aligned icon header topHeader\\">
           <div className=\\"centerTextContainer\\">

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`should render a section 1`] = `
               <div className=\\"Results__spacer\\" />
               <DropdownMenuWrapper onSignIn={[Function: onSignIn]} onSignOut={[Function: onSignOut]} userInfo={{...}}>
                 <NotifSignUpButton onNotifSignUp={[Function: onNotifSignUp]}>
-                  <button disabled={true} onClick={[Function: onClickWithAmplitudeHook]} type=\\"button\\" className=\\"Results_SignIn disabledButton\\">
+                  <button disabled={false} onClick={[Function: onClickWithAmplitudeHook]} type=\\"button\\" className=\\"Results_SignIn \\">
                     Sign In
                   </button>
                 </NotifSignUpButton>

--- a/pages/[campus]/[termId].tsx
+++ b/pages/[campus]/[termId].tsx
@@ -28,6 +28,7 @@ import Cookies from 'universal-cookie';
 import TestimonialToast from '../../components/Testimonial/TestimonialToast';
 import macros from '../../components/macros';
 import DisabledNotificationsModal from '../../components/notifications/DisabledNotificationsModal';
+import NewSubscriptionsLimitModal from '../../components/notifications/NewSubscriptionsLimitModal';
 
 const grad_banner_data: AlertBannerData = {
   text: 'has just released!',
@@ -50,25 +51,24 @@ export default function Home(): ReactElement {
 
   const { userInfo, fetchUserInfo, onSignIn, onSignOut } = useUserInfo();
 
+  const [showNewLimitModal, setShowNewLimitModal] = useState(false);
 
-  const [showNotificationsDisabledModal, setShowNotificationsDisabledModal] = useState(false);
-
-  const fetchNotificationsToken = async (): Promise<void> => {
+  const fetchModalToken = async (): Promise<void> => {
     const cookies = new Cookies();
-    const existingToken = cookies.get('NotificationsModal JWT');
+    const existingToken = cookies.get('NewLimitModal JWT');
     // Show modal twice
     if (!existingToken) {
-      setShowNotificationsDisabledModal(true);
-      cookies.set('NotificationsModal JWT', 1, { path: '/' });
+      setShowNewLimitModal(true);
+      cookies.set('NewLimitModal JWT', 1, { path: '/' });
     } else if (parseFloat(existingToken) < 2) {
-      setShowNotificationsDisabledModal(true);
-      cookies.set('NotificationsModal JWT', 2, { path: '/' });
+      setShowNewLimitModal(true);
+      cookies.set('NewLimitModal JWT', 2, { path: '/' });
     }
   };
 
   // Remove if no longer a need for the testimonial modal
   // const [showHelpModal, setShowHelpModal] = useState(false);
-  
+
   // const fetchFeedbackToken = async (): Promise<void> => {
   //   const cookies = new Cookies();
   //   const existingToken = cookies.get('FeedbackModal JWT');
@@ -81,7 +81,7 @@ export default function Home(): ReactElement {
 
   useEffect(() => {
     // fetchFeedbackToken();
-    fetchNotificationsToken();
+    fetchModalToken();
     fetchUserInfo();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -131,9 +131,9 @@ export default function Home(): ReactElement {
             onCancel={() => setShowHelpModal(false)}
           /> */}
 
-          <DisabledNotificationsModal
-            visible={showNotificationsDisabledModal}
-            onCancel={() => setShowNotificationsDisabledModal(false)}
+          <NewSubscriptionsLimitModal
+            visible={showNewLimitModal}
+            onCancel={() => setShowNewLimitModal(false)}
           />
 
           <div>


### PR DESCRIPTION
# Purpose
We are limiting users to 12 total subscriptions per semester to ensure SearchNEU can stay up and running for our growing user base. This implements these new sub limits and enables the sign in / notification buttons. A new modal is also added to update visitors on these new changes.


# Tickets
https://trello.com/c/JbNEe9f9/434-implement-12-total-subscriptions-limit-per-user


# Contributors
@ananyaspatil 


# Feature List
- Limit User to 12 total subscriptions (can be any combination of course or section subscriptions)
          ->  notification buttons are disabled when user has reached 12 subscriptions
- Modal w/ new limits info to replace current "Notifications Closed for the Summer" modal
- Enable 'Sign in' button

# Pictures

new modal:
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/58e48033-0403-4739-9645-ae72a8ef152d">


# Reviewers
@pranavphadke1 @sebwittr @Lucas-Dunker @Anzhuo-W 

