### PR TITLE
Semester dropdown bugfix

### DIFF
--- a/components/ResultsPage/SemesterDropdown.tsx
+++ b/components/ResultsPage/SemesterDropdown.tsx
@@ -42,12 +42,7 @@ function SemesterDropdown({
         onClick={() => setIsOpen(!isOpen)}
       >
         <div className={`DropdownFilter__search ${getDropdownStatus()}`}>
-          <input
-            className={'DropdownFilter__input'}
-            tabIndex={0}
-            type="text"
-            defaultValue={currentText}
-          ></input>
+          <div>{currentText}</div>
           <DropdownArrow
             aria-label="Dropdown arrow"
             className={`DropdownFilter__icon ${getDropdownStatus()}`}

--- a/components/ResultsPage/SemesterDropdown.tsx
+++ b/components/ResultsPage/SemesterDropdown.tsx
@@ -42,7 +42,7 @@ function SemesterDropdown({
         onClick={() => setIsOpen(!isOpen)}
       >
         <div className={`DropdownFilter__search ${getDropdownStatus()}`}>
-          <div>{currentText}</div>
+          <div aria-label={currentText}>{currentText}</div>
           <DropdownArrow
             aria-label="Dropdown arrow"
             className={`DropdownFilter__icon ${getDropdownStatus()}`}

--- a/components/tests/pages/__snapshots__/Result.test.tsx.snap
+++ b/components/tests/pages/__snapshots__/Result.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`should render a section 1`] = `
                 </div>
                 <div className=\\"DropdownFilter__dropdown\\" role=\\"button\\" tabIndex={0} onClick={[Function: onClick]}>
                   <div className=\\"DropdownFilter__search \\">
-                    <input className=\\"DropdownFilter__input\\" tabIndex={0} type=\\"text\\" defaultValue=\\"\\" />
+                    <div aria-label=\\"\\" />
                     <SvgDropdownArrow aria-label=\\"Dropdown arrow\\" className=\\"DropdownFilter__icon \\">
                       <svg aria-label=\\"Dropdown arrow\\" className=\\"DropdownFilter__icon \\" data-file-name=\\"SvgDropdownArrow\\" />
                     </SvgDropdownArrow>


### PR DESCRIPTION
# Purpose

The semester dropdown input was not updating. Input was also not used to filter semesters. The dropdown no longer has input and displays the current semester. 

# Tickets

- https://github.com/orgs/sandboxnu/projects/20/views/1?pane=issue&itemId=80297175

# Contributors

- @cherman23 

# Images

Can see how it is possible to type:
<img width="206" alt="searchNEU_inputbox" src="https://github.com/user-attachments/assets/a2b74079-4ecc-4b55-a395-b7f26f8710f6">

Can see how cannot type in box:
<img width="185" alt="SearchNEU_notInput" src="https://github.com/user-attachments/assets/543884a0-26d2-4b4e-9a05-d09cdc4bb19c">

# Feature List

_Expand on the purpose - what does this code do, and how? This should be a list of the changes, more in-depth and technical_

- Displays currentText variable (The current selected semester) within a div element.
- Update the jest snapshot to the current image of the results page to pass the snapshot test. 

# Reviewers

Primary reviewer:

- @ananyaspatil 

Secondary reviewers:

- @mehallhm 
- @Anzhuo-W 
- @nickpfeiffer05 
