### PR TITLE
Fixes notification spam upon sign in.

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -70,16 +70,17 @@ export const DropdownMenuWrapper = ({
   onSignIn,
 }: DropdownMenuWrapperProps): ReactElement => {
   const [showModal, setShowModal] = useState(false);
-  const showMenuDropdown = useRef(false);
+  // const showMenuDropdown = useRef(false);
+  const [showMenuDropdown, setShowMenuDropdown] = useState(false);
   const dropdownRef = useRef(null);
   const router = useRouter();
 
   const [userLoggedOut, setUserLoggedOut] = useState(false);
-  
+
   useEffect(() => {
     const handleCloseDropdown = (event: Event): void => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-        showMenuDropdown.current = false;
+        setShowMenuDropdown(false);
       }
     };
 
@@ -96,7 +97,7 @@ export const DropdownMenuWrapper = ({
 
   const DropDownMenu = useMemo(() => {
     const toggleMenuDropdown = (): void => {
-      showMenuDropdown.current = !showMenuDropdown.current;
+      setShowMenuDropdown(!showMenuDropdown);
     };
 
     const MemoizedDropDownMenu = (): ReactElement => (
@@ -123,8 +124,14 @@ export const DropdownMenuWrapper = ({
           </div>
         </div>
 
-        {showMenuDropdown.current && (
-          <div ref={dropdownRef} onClick={() => {onSignOut(), setUserLoggedOut(true)}} className="user-menu__dropdown">
+        {showMenuDropdown && (
+          <div
+            ref={dropdownRef}
+            onClick={() => {
+              onSignOut(), setUserLoggedOut(true);
+            }}
+            className="user-menu__dropdown"
+          >
             <span className="user-menu__item">
               <Exit style={{ marginRight: '8px' }} />
               <div className="user-menu__item--text-container">
@@ -142,8 +149,8 @@ export const DropdownMenuWrapper = ({
     MemoizedDropDownMenu.displayName = 'DropDownMenu';
 
     return MemoizedDropDownMenu;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  },[showMenuDropdown.current, userInfo?.token]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showMenuDropdown, userInfo?.token]);
 
   return (
     <>
@@ -155,10 +162,13 @@ export const DropdownMenuWrapper = ({
           <SignUpModal
             visible={showModal}
             onCancel={() => setShowModal(false)}
-            onSignIn={(token: string) => {onSignIn(token); setUserLoggedOut(false)}}
+            onSignIn={(token: string) => {
+              onSignIn(token);
+              setUserLoggedOut(false);
+            }}
             onSuccess={() => {
               setShowModal(false);
-              showMenuDropdown.current = false;
+              setShowMenuDropdown(false);
             }}
           />
         </>

--- a/utils/useUserInfo.ts
+++ b/utils/useUserInfo.ts
@@ -49,7 +49,7 @@ const useUserInfo = (): useUserInfoReturn => {
       setIsUserInfoLoading(false);
     };
     fetchData();
-  }, [cookies]);
+  }, []);
 
   return { userInfo, isUserInfoLoading, fetchUserInfo, onSignOut, onSignIn };
 };


### PR DESCRIPTION
# Purpose

This fixes the spamming of requests upon user sign in. This also fixes the dropdown sign out menu that wouldn't load.

# Tickets

Github issue here : https://github.com/sandboxnu/searchneu/issues/278

# Contributors

@mehallhm 
@cherman23 

# Feature List

- The getUserInfo() method in the utils/useUserInfo updates a user's cookies on sign-in. Within the same method, this would cause useEffect() to trigger due to the cookies being changed. The useEffectHook would also update cookies, causing a positive feedback loop that would result in network spamming.
- The spamming is prevented by not updating cookies within the useEffectHook().
- This change comes from a previous PR, where cookies were changed from a state variable. This can be found here: https://github.com/sandboxnu/searchneu/commit/88b525a4b058aae6a3e0f16c486e8db9d081862e#diff-f733484387256e891c78b27d74d50b723f95c02dce0d5463b163b1a40d2155a6. Due to how react deals with state, the useEffect() was not triggered previously.

- The showMenuDropdown was initially set up using a useRef hook, which would not be tracked during rendering. This is fixed by changing the showDropDown to a state variable where it is rendered correctly.


# Reviewers

**Primary**:

@ananyaspatil 

**Secondary**:

@nickpfeiffer05 
@Anzhuo-W 
@olivial215 
@serena-boyu 
