### PR TITLE
Added bottom corner radius to class cards 

### DIFF
--- a/components/ResultsPage/Results/CourseResult.tsx
+++ b/components/ResultsPage/Results/CourseResult.tsx
@@ -142,7 +142,11 @@ export function CourseResult({
       }
       afterBody={
         <>
-          <table className="SearchResult__sectionTable">
+          <table
+            className={`SearchResult__sectionTable ${
+              hideShowAll ? 'SearchResult__sectionTable--hidden' : ''
+            }`}
+          >
             <thead>
               <tr>
                 <th>

--- a/styles/results/_SearchResult.scss
+++ b/styles/results/_SearchResult.scss
@@ -160,6 +160,18 @@
     font-size: 16px;
   }
 
+  &__sectionTable--hidden tr:last-child td {
+    border-bottom: none;
+  }
+
+  &__sectionTable--hidden tr:last-child td:first-child {
+    border-bottom-left-radius: 5px;
+  }
+
+  &__sectionTable--hidden tr:last-child td:last-child {
+    border-bottom-right-radius: 5px;
+  }
+
   &__sectionTable > thead > tr > th {
     text-align: left;
     padding-left: 16px;


### PR DESCRIPTION
# Purpose

Some class cards were not properly rounded in the bottom left and bottom right corners. Specifically, any class card that did not have a "Show all sections" footer was not rounded properly. 

# Tickets

https://github.com/orgs/sandboxnu/projects/20/views/1?pane=issue&itemId=82334205

# Contributors

@nickpfeiffer05 

# Feature List

Added CSS styles for the case when "Show all sections" is not present. The styles specifically add a corner radius to the bottom left and bottom right table elements. 

# Pictures

Before: 

![image](https://github.com/user-attachments/assets/d7d7d6b1-7658-4c93-a559-95605cc37509)

![image](https://github.com/user-attachments/assets/6c0aabb3-f296-4e5b-a604-24a2a07096dd)

After: 

![image](https://github.com/user-attachments/assets/9122abef-33d1-4ba8-986b-e1e1c129704e)

![image](https://github.com/user-attachments/assets/3603687e-73dc-46f5-ae6c-1238c53bb564)


# Reviewers

Primary reviewer:

**Primary**:

@ananyaspatil 

Secondary reviewers:

**Secondary**:

@Anzhuo-W @cherman23 @mehallhm 
