### PR TITLE
Remove subscription modal

### DIFF
--- a/components/tests/pages/__snapshots__/Home.test.js.snap
+++ b/components/tests/pages/__snapshots__/Home.test.js.snap
@@ -20,7 +20,6 @@ exports[`should render a section 1`] = `
       <div className=\\"signInButtonContainer\\">
         <DropdownMenuWrapper userInfo={{...}} onSignIn={[Function: onSignIn]} onSignOut={[Function: onSignOut]} />
       </div>
-      <NewSubscriptionsLimitModal visible={false} onCancel={[Function: onCancel]} />
       <div>
         <div className=\\"ui center spacing aligned icon header topHeader\\">
           <div className=\\"centerTextContainer\\">

--- a/pages/[campus]/[termId].tsx
+++ b/pages/[campus]/[termId].tsx
@@ -131,11 +131,6 @@ export default function Home(): ReactElement {
             onCancel={() => setShowHelpModal(false)}
           /> */}
 
-          <NewSubscriptionsLimitModal
-            visible={showNewLimitModal}
-            onCancel={() => setShowNewLimitModal(false)}
-          />
-
           <div>
             <div // TODO: Take this out and restyle this monstrosity from scratch
               className="ui center spacing aligned icon header topHeader"


### PR DESCRIPTION
# Purpose

After two weeks of turning on notifications modal, we are removing it from popping up. 
Removed instance of Notification from home page and update snapshots to match changes.

# Tickets

https://github.com/orgs/sandboxnu/projects/20?pane=issue&itemId=85788239


# Pictures

Before:
![image](https://github.com/user-attachments/assets/9881ecf7-0ad0-4a58-84c3-383921c954ed)

After:
![image](https://github.com/user-attachments/assets/3593e187-b698-46f7-bc50-b6f3a15208d1)

# Reviewers

Primary reviewer:
@ananyaspatil 

Secondary reviewers:

@mehallhm 
@Anzhuo-W 
@nickpfeiffer05 