### PR TITLE
Edit Modal Message, add fix to CourseCheckBox

### DIFF
--- a/components/notifications/NewSubscriptionsLimitModal.tsx
+++ b/components/notifications/NewSubscriptionsLimitModal.tsx
@@ -25,11 +25,11 @@ export default function NewSubscriptionsLimitModal({
             </button>
           </div>
           <Boston />
-          <span className="phone-modal__header">Notifications are up!</span>
+          <span className="phone-modal__header">Unable to turn on notifs?</span>
 
           <span className="phone-modal__label">
-            We{`'`}re limiting users to 12 subscriptions at a time to keep
-            SearchNEU running for our growing NEU community.
+            Users are limited to 12 notifications at a time. Please unsubscribe
+            from a class to turn on other notifications.
           </span>
         </div>
       </div>

--- a/components/notifications/NewSubscriptionsLimitModal.tsx
+++ b/components/notifications/NewSubscriptionsLimitModal.tsx
@@ -26,15 +26,21 @@ export default function NewSubscriptionsLimitModal({
             </button>
           </div>
           <CryingHusky3 />
-          <span className="phone-modal__header">Notifications Issues</span>
+          <span className="phone-modal__header">Recent Issues</span>
 
           <span className="phone-modal__label">
-            We found issues with unsubscribing from notifications.
+            We have identified issues with unsubscribing from notifications.
           </span>
           <span className="phone-modal__label">
-            We are very sorry about the inconvenience this causes, and are
-            working to deploy fixes ASAP. Thank you!
+            Additionally, we have not been been displaying professor names as
+            Banner recently changed how it shows professor data.
           </span>
+          <br />
+          <span className="phone-modal__label">
+            We are very sorry about the inconvenience these issues cause, and
+            are working to deploy fixes ASAP. Thank you!
+          </span>
+          <br />
         </div>
       </div>
     </Modal>

--- a/components/notifications/NewSubscriptionsLimitModal.tsx
+++ b/components/notifications/NewSubscriptionsLimitModal.tsx
@@ -26,7 +26,7 @@ export default function NewSubscriptionsLimitModal({
             </button>
           </div>
           <CryingHusky3 />
-          <span className="phone-modal__header">Recent Issues</span>
+          <span className="phone-modal__header">Notification Issues</span>
 
           <span className="phone-modal__label">
             We have identified issues with unsubscribing from notifications.

--- a/components/notifications/NewSubscriptionsLimitModal.tsx
+++ b/components/notifications/NewSubscriptionsLimitModal.tsx
@@ -29,10 +29,10 @@ export default function NewSubscriptionsLimitModal({
           <span className="phone-modal__header">Notifications Issues</span>
 
           <span className="phone-modal__label">
-            We've found issues with unsubscribing from notifications.
+            We found issues with unsubscribing from notifications.
           </span>
           <span className="phone-modal__label">
-            We're very sorry about the inconvenience this causes, and are
+            We are very sorry about the inconvenience this causes, and are
             working to deploy fixes ASAP. Thank you!
           </span>
         </div>

--- a/components/notifications/NewSubscriptionsLimitModal.tsx
+++ b/components/notifications/NewSubscriptionsLimitModal.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import Modal from '../Modal';
 import X from '../icons/X.svg';
 import Boston from '../icons/boston.svg';
+import CryingHusky3 from '../icons/crying-husky-3.svg';
 
 interface NewSubscriptionsLimitModalProps {
   visible: boolean;
@@ -24,12 +25,15 @@ export default function NewSubscriptionsLimitModal({
               <X />
             </button>
           </div>
-          <Boston />
-          <span className="phone-modal__header">Unable to turn on notifs?</span>
+          <CryingHusky3 />
+          <span className="phone-modal__header">Notifications Issues</span>
 
           <span className="phone-modal__label">
-            Users are limited to 12 notifications at a time. Please unsubscribe
-            from a class to turn on other notifications.
+            We've found issues with unsubscribing from notifications.
+          </span>
+          <span className="phone-modal__label">
+            We're very sorry about the inconvenience this causes, and are
+            working to deploy fixes ASAP. Thank you!
           </span>
         </div>
       </div>

--- a/components/panels/CourseCheckBox.tsx
+++ b/components/panels/CourseCheckBox.tsx
@@ -85,7 +85,8 @@ export default function CourseCheckBox({
       <div className="signUpSwitch toggle">
         <div className="notifSwitch">
           <input
-            disabled={notificationsLimitReached()}
+            //disabled={notificationsLimitReached()}
+            disabled={checked ? false : notificationsLimitReached()}
             checked={checked}
             onChange={onCheckboxClick}
             className="react-switch-checkbox"
@@ -94,11 +95,17 @@ export default function CourseCheckBox({
           />
           <label
             //className={`react-switch-label ${NOTIFICATIONS_ARE_DISABLED && 'disabledButton'}`}
-            className={`react-switch-label ${notificationsLimitReached()}`}
+            className={`react-switch-label ${
+              //notificationsLimitReached()
+              !checked && notificationsLimitReached() && 'disabledButton'
+            }`}
             style={{
               marginTop: '0px',
               cursor: `${
-                notificationsLimitReached() ? 'not-allowed' : 'inherit'
+                //notificationsLimitReached() ? 'not-allowed' : 'inherit'
+                !checked && notificationsLimitReached()
+                  ? 'not-allowed'
+                  : 'inherit'
               }`,
             }}
             htmlFor={notifSwitchId}
@@ -106,14 +113,25 @@ export default function CourseCheckBox({
             <span className="react-switch-button" />
           </label>
         </div>
-        <Tooltip
-          text={
-            checked
-              ? 'Unsubscribe from notifications for this course.'
-              : 'Subscribe to notifications for this course'
-          }
-          direction={TooltipDirection.Up}
-        />
+        {checked ||
+          (!notificationsLimitReached() && (
+            <Tooltip
+              text={
+                !userInfo
+                  ? 'Sign in to subscribe for notifications.'
+                  : checked
+                  ? 'Unsubscribe from notifications for this section.'
+                  : 'Subscribe to notifications for this section'
+              }
+              direction={TooltipDirection.Up}
+            />
+          ))}
+        {!checked && notificationsLimitReached() && (
+          <Tooltip
+            text="Notification limit reached - unsubscribe to add more."
+            direction={TooltipDirection.Up}
+          />
+        )}
       </div>
       <SignUpModal
         visible={showModal}


### PR DESCRIPTION
# Purpose
Allow users that reached the 12 notif limit to unsubscribe from course notifications.


# Tickets
Hotfix

#Pictures   
<img width="906" alt="image" src="https://github.com/user-attachments/assets/3a23f4ea-b93d-4c6d-9c83-0dd1d8a2127d">


# Contributors
@ananyaspatil 

# Feature List
- Added same fix from PR #286 to CourseCheckBox.
- Edited the Modal Message to direct users to unsubscribe from notifs if their toggles are disabled.

# Reviewers
@mehallhm @Anzhuo-W @Lucas-Dunker @cherman23 @nickpfeiffer05 @elvincheng3 



