### PR TITLE
Filter out prev semester notifs 

### DIFF
--- a/components/panels/CourseCheckBox.tsx
+++ b/components/panels/CourseCheckBox.tsx
@@ -11,6 +11,7 @@ import { Course, SubscriptionCourse } from '../types';
 import axios from 'axios';
 import { UserInfo } from '../../components/types';
 import SignUpModal from '../notifications/modal/SignUpModal';
+import { gqlClient } from '/Users/user/searchneu/utils/courseAPIClient';
 
 type CourseCheckBoxProps = {
   course: Course | SubscriptionCourse;
@@ -30,12 +31,20 @@ export default function CourseCheckBox({
 
   const NOTIFICATIONS_LIMIT = 12;
   const NOTIFICATIONS_ARE_DISABLED = false;
+  const CURRENT_TERM = '202530';
+
+  const currentCourseNotifs = userInfo
+    ? userInfo.courseIds.filter(async (c) => {
+        const result = await gqlClient.getCourseInfoByHash({
+          hash: c,
+        });
+        return result.classByHash.termId === CURRENT_TERM;
+      }).length
+    : 0;
 
   const notificationsLimitReached = (): boolean =>
     NOTIFICATIONS_ARE_DISABLED ||
-    (userInfo &&
-      userInfo.courseIds.length + userInfo.sectionIds.length >=
-        NOTIFICATIONS_LIMIT);
+    (userInfo && currentCourseNotifs >= NOTIFICATIONS_LIMIT);
 
   const isCourseChecked = (): boolean =>
     userInfo && userInfo.courseIds.includes(Keys.getClassHash(course));

--- a/components/panels/SectionCheckBox.tsx
+++ b/components/panels/SectionCheckBox.tsx
@@ -13,6 +13,7 @@ import axios from 'axios';
 import { UserInfo } from '../../components/types';
 import Colors from '../../styles/_exports.module.scss';
 import SignUpModal from '../notifications/modal/SignUpModal';
+import { gqlClient } from '/Users/user/searchneu/utils/courseAPIClient';
 
 type SectionCheckBoxProps = {
   section: Section;
@@ -32,12 +33,23 @@ export default function SectionCheckBox({
 
   const NOTIFICATIONS_LIMIT = 12;
   const NOTIFICATIONS_ARE_DISABLED = false;
+  const CURRENT_TERM = '202530';
+
+  const currentSectionNotifs = userInfo
+    ? userInfo.sectionIds.filter(async (s) => {
+        const sectionHashSlice = s.split('/');
+        const courseHash = sectionHashSlice.slice(0, -1).join('/');
+
+        const courseResult = await gqlClient.getCourseInfoByHash({
+          hash: courseHash,
+        });
+        return courseResult.classByHash.termId === CURRENT_TERM;
+      }).length
+    : 0;
 
   const notificationsLimitReached = (): boolean =>
     NOTIFICATIONS_ARE_DISABLED ||
-    (userInfo &&
-      userInfo.courseIds.length + userInfo.sectionIds.length >=
-        NOTIFICATIONS_LIMIT);
+    (userInfo && currentSectionNotifs >= NOTIFICATIONS_LIMIT);
 
   const isSectionChecked = (): boolean =>
     userInfo


### PR DESCRIPTION
# Purpose
When we check if a user has reached the notif limit, only count courses and sections with a termID of the current semester.

# Tickets


# Contributors
@ananyaspatil 

# Feature List
In both CourseCheckBox and SectionCheckBox, filters for courses/sections from the current termID.
It counts these current subscriptions to determine if the notif limit is reached. Rn termID is hardcoded - that should be changed.
-
# Reviewers
@mehallhm @elvincheng3 @Lucas-Dunker @Anzhuo-W 
