### PR TITLE
Updated Mobile Semester Dropdown

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -21,7 +21,7 @@ import {
   QUERY_PARAM_ENCODERS,
 } from '../components/ResultsPage/filters';
 import SearchBar from '../components/ResultsPage/SearchBar';
-import SearchDropdown from '../components/ResultsPage/SearchDropdown';
+import { MobileSearchDropdown } from '../components/ResultsPage/SearchDropdown';
 import useAtTop from '../components/ResultsPage/useAtTop';
 import {
   Campus,
@@ -239,6 +239,10 @@ export default function Header({
     );
   }
 
+  function formatSemester(semester: string): string {
+    return semester.replace(/(\w+(?: \d)?) (\d{4}) Semester/, '$1 ($2)');
+  }
+
   return (
     <div>
       <Head>
@@ -292,31 +296,18 @@ export default function Header({
         )}
         {macros.isMobile && searchData && (
           <div className="Breadcrumb_Container">
-            <div className="Breadcrumb_Container__dropDownContainer">
-              <SearchDropdown
-                options={Object.keys(Campus).map((c: Campus) => ({
-                  text: c,
-                  value: c,
-                  link: termAndCampusToURLCallback(
-                    getRoundedTerm(termInfos, c, termId),
-                    c
-                  ),
-                }))}
-                value={campus}
-                className="searchDropdown"
-                compact={false}
-              />
-            </div>
-            <span className="Breadcrumb_Container__slash">/</span>
-            <div className="Breadcrumb_Container__dropDownContainer">
-              <SearchDropdown
+            <div className="Breadcrumb_Container1__dropDownContainer">
+              <MobileSearchDropdown
                 options={termInfos[campus].map((terminfo) => ({
-                  text: terminfo.text,
+                  text: terminfo.text.replace(
+                    /(\w+(?: \d+| Full)?) (\d{4}) Semester/,
+                    '$1 ($2)'
+                  ), // parse into desired format
                   value: terminfo.value,
                   link: termAndCampusToURLCallback(terminfo.value, campus),
                 }))}
                 value={termId}
-                className="searchDropdown"
+                className="mobileSearchDropdown"
                 compact={false}
                 key={campus}
               />

--- a/components/ResultsPage/SearchDropdown.tsx
+++ b/components/ResultsPage/SearchDropdown.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState, useEffect, useRef } from 'react';
 import { Dropdown } from 'semantic-ui-react';
 
 interface ItemProps {
@@ -14,7 +14,7 @@ interface DropdownProps {
   compact: boolean;
 }
 
-function SearchDropdown({
+export function SearchDropdown({
   options,
   value: currentValue,
   className = 'searchDropdown',
@@ -39,6 +39,70 @@ function SearchDropdown({
         ))}
       </Dropdown.Menu>
     </Dropdown>
+  );
+}
+
+export function MobileSearchDropdown({
+  options,
+  value: currentValue,
+  className = 'searchDropdown',
+  compact = false,
+}: DropdownProps): ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const currentOption = options.find((o) => o.value === currentValue);
+  const currentText = currentOption ? currentOption.text : '';
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('click', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <div
+      ref={dropdownRef}
+      className={`mobile-search-dropdown ${className} ${
+        compact ? `${className}--compact` : ''
+      }`}
+    >
+      <button
+        className="mobile-search-dropdown-button"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        {currentText}
+
+        <img
+          src="/semester-dropdown-arrow.svg"
+          alt="Dropdown Arrow"
+          className={`dropdown-arrow ${isOpen ? 'flipped' : ''}`}
+        />
+      </button>
+
+      {isOpen && (
+        <ul className="mobile-search-dropdown-menu">
+          {options.map(({ text, value, link }) => (
+            <li key={value}>
+              <a href={link} onClick={() => setIsOpen(false)}>
+                {text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }
 

--- a/public/semester-dropdown-arrow.svg
+++ b/public/semester-dropdown-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="9" height="6" viewBox="0 0 9 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path id="Polygon 10" d="M4.5 6L0 0L9 0L4.5 6Z" fill="#525252"/>
+</svg>

--- a/styles/_SearchDropdown.scss
+++ b/styles/_SearchDropdown.scss
@@ -50,3 +50,83 @@
     }
   }
 }
+
+.mobile-search-dropdown {
+  display: inline-block;
+  min-width: max-content;
+  position: relative;
+  z-index: 1;
+
+  .mobile-search-dropdown-button {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    text-align: left;
+    margin-right: 15px;
+
+    font-family: 'Lato';
+    font-size: 13px;
+    font-weight: 600;
+
+    background-color: #f1f3f5;
+    color: #333;
+
+    border: none;
+    border-radius: 30px;
+    padding: 7px 15px 7px 17px;
+
+    cursor: pointer;
+    pointer-events: initial;
+  }
+
+  .mobile-search-dropdown-menu {
+    width: 100%;
+    max-height: 140px;
+    position: absolute;
+    top: calc(100% + 5px);
+    left: 0;
+    overflow-y: auto;
+    background: #fff !important;
+    border-radius: 30px;
+    padding: 8px 0;
+    z-index: 2;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+    list-style-type: none;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    li {
+      font-family: 'Lato';
+      list-style: none;
+      font-size: 13px;
+      font-weight: 600;
+      padding: 5px 17px;
+
+      a {
+        text-decoration: none;
+        color: #333;
+        display: block;
+        width: 100%;
+      }
+    }
+
+    &::-webkit-scrollbar {
+      width: 0px;
+      height: 0px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: transparent;
+    }
+  }
+
+  .dropdown-arrow {
+    margin-left: 8px;
+    transition: transform 0.3s ease;
+  }
+
+  .flipped {
+    transform: rotate(180deg);
+  }
+}

--- a/styles/_SearchDropdown.scss
+++ b/styles/_SearchDropdown.scss
@@ -69,8 +69,8 @@
     font-size: 13px;
     font-weight: 600;
 
-    background-color: #f1f3f5;
-    color: #333;
+    background-color: Colors.$Secondary_Hover;
+    color: Colors.$Button_Text;
 
     border: none;
     border-radius: 30px;
@@ -87,7 +87,7 @@
     top: calc(100% + 5px);
     left: 0;
     overflow-y: auto;
-    background: #fff !important;
+    background: Colors.$White !important;
     border-radius: 20px;
     padding: 8px 0;
     z-index: 2;
@@ -105,7 +105,7 @@
 
       a {
         text-decoration: none;
-        color: #333;
+        color: Colors.$Button_Text;
         display: block;
         width: 100%;
       }

--- a/styles/_SearchDropdown.scss
+++ b/styles/_SearchDropdown.scss
@@ -88,7 +88,7 @@
     left: 0;
     overflow-y: auto;
     background: #fff !important;
-    border-radius: 30px;
+    border-radius: 20px;
     padding: 8px 0;
     z-index: 2;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
@@ -109,6 +109,14 @@
         display: block;
         width: 100%;
       }
+    }
+
+    li:first-child {
+      padding-top: 0px;
+    }
+
+    li:last-child {
+      padding-bottom: 0px;
     }
 
     &::-webkit-scrollbar {

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -30,6 +30,7 @@ $Light_Blue: #b5cad8;
 
 // Utility Buttons
 $Secondary_Hover: #f1f3f5;
+$Button_Text: #333;
 
 // Modal Background
 $Modal_Background: #21212166;


### PR DESCRIPTION
# Purpose

Updated the semester dropdown on the search page to match new figma designs.

# Tickets

#297

# Feature List

- Updated semester dropdown styles based on Figma
- Changed semester display names to match Figma (previously was "Summer 1 Semester 2025", for example)
- Removed the NEU/CPS/Law dropdown next to this one because it's not in Figma anymore (mobile)


# Pictures

Before: 
![image](https://github.com/user-attachments/assets/2b717b44-f6f1-4d22-bbcd-c26a9fac8a95)



After: 
![image](https://github.com/user-attachments/assets/190b2062-05f7-467b-a4f7-837958849097)


# Reviewers

Primary reviewer:

**Primary**:

@ananyaspatil 
@mehallhm 

Secondary reviewers:

**Secondary**:

@cherman23  @WesleyTran0 @ItsEricSun 

