### PR TITLE
Got rid of html tags before description is put into a paragraph tag

### DIFF
--- a/components/ClassPage/ClassPageInfoBody.tsx
+++ b/components/ClassPage/ClassPageInfoBody.tsx
@@ -18,7 +18,7 @@ export default function ClassPageInfoBody({
       <div className="classPageBodyLeft">
         <HeaderBody
           header="COURSE DESCRIPTION"
-          body={<p>{latestOccurrence.desc}</p>}
+          body={<p>{stripHTMLTags(latestOccurrence.desc)}</p>}
         />
         <HeaderBody
           header="COURSE LEVEL"
@@ -70,6 +70,14 @@ export default function ClassPageInfoBody({
       </div>
     </div>
   );
+}
+
+function stripHTMLTags(text: string): string {
+  if (text.includes('</')) {
+    const indxOfOpenTag = text.indexOf('>') + 2;
+    return text.substring(0, text.indexOf('</')).substring(indxOfOpenTag);
+  }
+  return text;
 }
 
 function getCourseLevel(termId: string): string {


### PR DESCRIPTION
# Purpose

Adds a strip html tag function
gets rid of the unwanted tags in the course description

# Tickets
#239 
-

# Contributors

@WesleyTran0 

# Feature List

- Added function in classPageInfo to string HTML tags from a string.
- Strips the HTML tag from the course description before putting it into a paragraph tag to be passed into the header body


# Pictures
Before:
![image](https://github.com/user-attachments/assets/36eb3295-fd6c-4a1f-b104-a4ca7981367c)
After:
![image](https://github.com/user-attachments/assets/bfbc026e-3f72-43b5-87ee-8b8f8f8ec8e0)

# Reviewers

Primary reviewer:

**Primary**: @mehallhm 

Use the **"Reviewers"** feature in Github

Secondary reviewers: 

**Secondary**: @ItsEricSun @nick-pfeiffer @cherman23
