### PR TITLE
Prevent notification page from erroring when signing out

### DIFF
--- a/components/SubscriptionsPage/CRNBadge.tsx
+++ b/components/SubscriptionsPage/CRNBadge.tsx
@@ -1,5 +1,4 @@
 import { ReactElement } from 'react';
-import Keys from '../Keys';
 import { UserInfo } from '../types';
 
 type CRNBadgeProps = {
@@ -8,7 +7,7 @@ type CRNBadgeProps = {
 };
 
 export const CRNBadge = ({ crn, userInfo }: CRNBadgeProps): ReactElement => {
-  const subscribed = userInfo.sectionIds.map((str) =>
+  const subscribed = userInfo?.sectionIds.map((str) =>
     str.substring(str.lastIndexOf('/') + 1)
   );
 

--- a/components/SubscriptionsPage/ClassCard.tsx
+++ b/components/SubscriptionsPage/ClassCard.tsx
@@ -85,7 +85,7 @@ export function ClassCard({
             className="SearchResult__header--sub"
           />  */}
           <div className="SearchResult__header--sub">
-            {course.sections.map((section) => (
+            {sectionsFormatted.map((section) => (
               <CRNBadge
                 key={section.crn}
                 userInfo={userInfo}


### PR DESCRIPTION
# Purpose

Notification page errors when signing out. Fix prevents error by not attempting to access user data. This is a hotfix and the reasoning for the current page reloading when signing out should be investigated. 

# Tickets

no ticket

# Contributors

@cherman23 

# Reviewers

Primary reviewer:

@mehallhm 
@ananyaspatil 