### PR TITLE
329: Unsubscribed classes remain on subscriptions page

### DIFF
--- a/components/ResultsPage/Results/CourseResult.tsx
+++ b/components/ResultsPage/Results/CourseResult.tsx
@@ -180,12 +180,14 @@ export function CourseResult({
                 <tr>
                   <td colSpan={5}>New available sections</td>
                   <td>
-                    <CourseCheckBox
-                      course={course}
-                      userInfo={userInfo}
-                      onSignIn={onSignIn}
-                      fetchUserInfo={fetchUserInfo}
-                    />
+                    <div className="DesktopSectionPanel__notifs">
+                      <CourseCheckBox
+                        course={course}
+                        userInfo={userInfo}
+                        onSignIn={onSignIn}
+                        fetchUserInfo={fetchUserInfo}
+                      />
+                    </div>
                   </td>
                 </tr>
               </tfoot>

--- a/components/SubscriptionsPage/ClassCard.tsx
+++ b/components/SubscriptionsPage/ClassCard.tsx
@@ -152,12 +152,14 @@ export function ClassCard({
                   <tr>
                     <td colSpan={5}>New available sections</td>
                     <td>
-                      <CourseCheckBox
-                        course={course}
-                        userInfo={userInfo}
-                        fetchUserInfo={fetchUserInfo}
-                        onSignIn={onSignIn}
-                      />
+                      <div className="DesktopSectionPanel__notifs">
+                        <CourseCheckBox
+                          course={course}
+                          userInfo={userInfo}
+                          fetchUserInfo={fetchUserInfo}
+                          onSignIn={onSignIn}
+                        />
+                      </div>
                     </td>
                   </tr>
                 </tfoot>

--- a/components/SubscriptionsPage/EmptyCard.tsx
+++ b/components/SubscriptionsPage/EmptyCard.tsx
@@ -16,7 +16,6 @@ export const EmptyCard = (): ReactElement => {
   const termInfos = getTermInfosWithError().termInfos;
   // note: not sure of a way to find current campus, if not create it?
   const termId = getLatestTerm(termInfos, Campus.NEU);
-  const termName = getTermName(termInfos, termId).replace('Semester', '');
 
   return (
     <>

--- a/components/SubscriptionsPage/EmptyCard.tsx
+++ b/components/SubscriptionsPage/EmptyCard.tsx
@@ -27,7 +27,7 @@ export const EmptyCard = (): ReactElement => {
               <div className="Empty_Main_EmptyCard_Header">
                 <div className="Empty_Main__EmptyCard_Header_Spacer">
                   <div className="Empty_Main__EmptyCard_Header_Title">
-                    <b>{termName} Notifications</b>
+                    <b>Notifications</b>
                   </div>
                 </div>
                 {isHovering ? (

--- a/components/panels/CourseCheckBox.tsx
+++ b/components/panels/CourseCheckBox.tsx
@@ -33,7 +33,10 @@ export default function CourseCheckBox({
   const NOTIFICATIONS_LIMIT = 12;
   const NOTIFICATIONS_ARE_DISABLED = false;
 
-  const termId = router.query.termId as string;
+  // try to get the termId from the router query, if not available, fallback to the course's termId
+  const termId = router.query.termId
+    ? (router.query.termId as string)
+    : course.termId;
 
   const notificationsLimitReached = (): boolean =>
     NOTIFICATIONS_ARE_DISABLED ||
@@ -41,6 +44,24 @@ export default function CourseCheckBox({
       userInfo.courseIds.filter((id) => id.includes(termId)).length +
         userInfo.sectionIds.filter((id) => id.includes(termId)).length >=
         NOTIFICATIONS_LIMIT);
+
+  const getNumberOfNotifications = async (): Promise<number> => {
+    if (!userInfo) {
+      return 0;
+    }
+    try {
+      const res = await axios.get(
+        `${process.env.NEXT_PUBLIC_NOTIFS_ENDPOINT}/user/subscriptions/${userInfo.token}`
+      );
+      const count =
+        res.data.sectionIds.filter((id: string) => id.includes(termId)).length +
+        res.data.courseIds.filter((id: string) => id.includes(termId)).length;
+      return count;
+    } catch (err) {
+      console.error(err);
+      return 0;
+    }
+  };
 
   const isCourseChecked = (): boolean =>
     userInfo && userInfo.courseIds.includes(Keys.getClassHash(course));
@@ -51,11 +72,17 @@ export default function CourseCheckBox({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userInfo]);
 
-  function onCheckboxClick(): void {
+  async function onCheckboxClick(): Promise<void> {
     if (!userInfo) {
       setChecked(false);
       setShowModal(true);
     } else {
+      // Check again if the user is already subscribed to the maximum number of notifications
+      const numberOfNotifications = await getNumberOfNotifications();
+      if (!checked && numberOfNotifications >= NOTIFICATIONS_LIMIT) {
+        fetchUserInfo();
+        return;
+      }
       setChecked(!checked);
       if (checked) {
         axios

--- a/components/panels/SectionCheckBox.tsx
+++ b/components/panels/SectionCheckBox.tsx
@@ -35,7 +35,10 @@ export default function SectionCheckBox({
   const NOTIFICATIONS_LIMIT = 12;
   const NOTIFICATIONS_ARE_DISABLED = false;
 
-  const termId = router.query.termId as string;
+  // try to get the termId from the router query, if not available, fallback to the section's termId
+  const termId = router.query.termId
+    ? (router.query.termId as string)
+    : Keys.getSectionHash(section).split('/')[1];
 
   const notificationsLimitReached = (): boolean =>
     NOTIFICATIONS_ARE_DISABLED ||
@@ -43,6 +46,24 @@ export default function SectionCheckBox({
       userInfo.courseIds.filter((id) => id.includes(termId)).length +
         userInfo.sectionIds.filter((id) => id.includes(termId)).length >=
         NOTIFICATIONS_LIMIT);
+
+  const getNumberOfNotifications = async (): Promise<number> => {
+    if (!userInfo) {
+      return 0;
+    }
+    try {
+      const res = await axios.get(
+        `${process.env.NEXT_PUBLIC_NOTIFS_ENDPOINT}/user/subscriptions/${userInfo.token}`
+      );
+      const count =
+        res.data.sectionIds.filter((id: string) => id.includes(termId)).length +
+        res.data.courseIds.filter((id: string) => id.includes(termId)).length;
+      return count;
+    } catch (err) {
+      console.error(err);
+      return 0;
+    }
+  };
 
   const isSectionChecked = (): boolean =>
     userInfo
@@ -55,12 +76,17 @@ export default function SectionCheckBox({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userInfo]);
 
-  function onCheckboxClick(): void {
+  async function onCheckboxClick(): Promise<void> {
     if (!userInfo) {
       setChecked(false);
       setShowModal(true);
     } else {
-      setChecked(!checked);
+      // Check again if the user is already subscribed to the maximum number of notifications
+      const numberOfNotifications = await getNumberOfNotifications();
+      if (!checked && numberOfNotifications >= NOTIFICATIONS_LIMIT) {
+        fetchUserInfo();
+        return;
+      }
       if (checked) {
         axios
           .delete(
@@ -89,7 +115,7 @@ export default function SectionCheckBox({
     }
   }
 
-  if (section.seatsRemaining > 5) {
+  if (section.seatsRemaining > 0 && !checked) {
     return (
       <div
         style={{ color: Colors.light_grey }}

--- a/pages/subscriptions.tsx
+++ b/pages/subscriptions.tsx
@@ -141,7 +141,7 @@ export default function SubscriptionsPage(): ReactElement {
   //   },
   // }
   // When displayed, its most recent semester first (highest termId), then courses in alphabetical order
-  const [classes, setClasses] = useState(
+  const [terms, setTerms] = useState(
     new Map<string, Map<string, SubscriptionCourse>>()
   );
 
@@ -151,8 +151,6 @@ export default function SubscriptionsPage(): ReactElement {
   const [isSubscribed, setIsSubscribed] = useState(false);
 
   const termInfos = getTermInfosWithError().termInfos;
-  const termId = getLatestTerm(termInfos, Campus.NEU);
-  const termName = getTermName(termInfos, termId).replace('Semester', '');
 
   useEffect(() => {
     if (isUserInfoLoading) {
@@ -165,15 +163,15 @@ export default function SubscriptionsPage(): ReactElement {
       return;
     }
 
-    const classMapping = new Map<string, Map<string, SubscriptionCourse>>();
+    const termMapping = new Map<string, Map<string, SubscriptionCourse>>();
     const fetchSubscriptions = async (): Promise<void> => {
       try {
-        await fetchCourseNotifs(classMapping, userInfo.courseIds);
-        await fetchSectionNotifs(classMapping, userInfo.sectionIds);
-        setClasses(classMapping);
+        await fetchCourseNotifs(termMapping, userInfo.courseIds);
+        await fetchSectionNotifs(termMapping, userInfo.sectionIds);
+        setTerms(termMapping);
         setIsFetching(false);
         // are there classes the user is subscribed to?
-        if (classMapping.size > 0) {
+        if (termMapping.size > 0) {
           setIsSubscribed(true);
         }
       } catch (e) {
@@ -184,8 +182,8 @@ export default function SubscriptionsPage(): ReactElement {
   }, [userInfo?.phoneNumber, isUserInfoLoading]);
 
   const unsubscribeAll = () => {
-    const allSections = Array.from(classes.values()).flatMap((courseMap) =>
-      Array.from(courseMap.values()).flatMap((course) => course.sections)
+    const allSections = Array.from(terms.values()).flatMap((termMap) =>
+      Array.from(termMap.values()).flatMap((course) => course.sections)
     );
     axios
       .delete(`${process.env.NEXT_PUBLIC_NOTIFS_ENDPOINT}/user/subscriptions`, {
@@ -248,13 +246,13 @@ export default function SubscriptionsPage(): ReactElement {
                 </button>
               </div>
               {/* Sort termId keys and iterate over them */}
-              {Array.from(classes.keys())
+              {Array.from(terms.keys())
                 .sort((a, b) => parseInt(b) - parseInt(a)) // Sort termIds in descending order
                 .map((termId) => (
                   <div key={termId}>
                     <h3>{getTermName(termInfos, termId)}</h3>
                     {/* Get the courses map for this termId and sort courses */}
-                    {Array.from(classes.get(termId)!.entries())
+                    {Array.from(terms.get(termId)!.entries())
                       .sort(([codeA], [codeB]) => codeA.localeCompare(codeB)) // Sort courses by courseCode
                       .map(([courseCode, course]) => (
                         <ClassCard

--- a/pages/subscriptions.tsx
+++ b/pages/subscriptions.tsx
@@ -13,7 +13,7 @@ import { Campus } from '../components/types';
 import Keys from '../components/Keys';
 import axios from 'axios';
 
-async function fetchCourseNotifs(classMapping, courseIds) {
+async function fetchCourseNotifs(termMapping, courseIds) {
   for (const courseId of courseIds) {
     const result = await gqlClient.getCourseInfoByHash({
       hash: courseId,
@@ -27,24 +27,28 @@ async function fetchCourseNotifs(classMapping, courseIds) {
     const host = result.classByHash.host;
     const termId = result.classByHash.termId;
 
-    // The subscription page should only show sections that we can subscribe to.
-    // We identify such sections as those with less than 5 seats remaining.
-    const filteredSections = result.classByHash.sections
-      .filter((s) => {
-        return s.seatsRemaining <= 5;
-      })
-      .map((s) => {
-        return {
-          ...s,
-          online: false,
-          subject: subject,
-          classId: classId,
-          host: host,
-          termId: termId,
-        };
-      });
+    const filteredSections = result.classByHash.sections.map((s) => {
+      return {
+        ...s,
+        online: false,
+        subject: subject,
+        classId: classId,
+        host: host,
+        termId: termId,
+      };
+    });
 
-    classMapping.set(courseCode, {
+    // If no sections are available, skip this course
+    if (filteredSections.length === 0) {
+      continue;
+    }
+
+    // Ensure termIdInt exists in the outer map
+    if (!termMapping.has(termId)) {
+      termMapping.set(termId, new Map());
+    }
+
+    termMapping.get(termId)!.set(courseCode, {
       subject: subject,
       classId: classId,
       termId: termId,
@@ -56,7 +60,7 @@ async function fetchCourseNotifs(classMapping, courseIds) {
   }
 }
 
-async function fetchSectionNotifs(classMapping, sectionIds) {
+async function fetchSectionNotifs(termMapping, sectionIds) {
   for (const sectionId of sectionIds) {
     const result = await gqlClient.getSectionInfoByHash({
       hash: sectionId,
@@ -64,35 +68,44 @@ async function fetchSectionNotifs(classMapping, sectionIds) {
     const courseCode =
       result.sectionByHash.subject + result.sectionByHash.classId;
 
-    // If course has already been found in fetchCourseNotifs(), continue
-    if (!classMapping.has(courseCode)) {
-      const sectionHashSlice = sectionId.split('/');
-      const courseHash = sectionHashSlice.slice(0, -1).join('/');
+    const sectionHashSlice = sectionId.split('/');
+    const courseHash = sectionHashSlice.slice(0, -1).join('/');
 
-      const courseResult = await gqlClient.getCourseInfoByHash({
-        hash: courseHash,
+    const courseResult = await gqlClient.getCourseInfoByHash({
+      hash: courseHash,
+    });
+
+    const subject = courseResult.classByHash.subject;
+    const classId = courseResult.classByHash.classId;
+    const host = courseResult.classByHash.host;
+    const termId = courseResult.classByHash.termId;
+
+    // Ensure termIdInt exists in the outer map
+    if (!termMapping.has(termId)) {
+      termMapping.set(termId, new Map());
+    }
+
+    const classMap = termMapping.get(termId)!;
+
+    // If course has already been found in fetchCourseNotifs(), continue
+    if (!classMap.has(courseCode)) {
+      const filteredSections = courseResult.classByHash.sections.map((s) => {
+        return {
+          ...s,
+          online: false,
+          subject: subject,
+          classId: classId,
+          host: host,
+          termId: termId,
+        };
       });
 
-      const subject = courseResult.classByHash.subject;
-      const classId = courseResult.classByHash.classId;
-      const host = courseResult.classByHash.host;
-      const termId = courseResult.classByHash.termId;
+      // If no sections are available, skip this course
+      if (filteredSections.length === 0) {
+        continue;
+      }
 
-      const filteredSections = courseResult.classByHash.sections
-        .filter((s) => {
-          return s.seatsRemaining <= 5;
-        })
-        .map((s) => {
-          return {
-            ...s,
-            online: false,
-            subject: subject,
-            classId: classId,
-            host: host,
-            termId: termId,
-          };
-        });
-      classMapping.set(courseCode, {
+      classMap.set(courseCode, {
         subject: subject,
         classId: classId,
         termId: termId,
@@ -114,7 +127,23 @@ export default function SubscriptionsPage(): ReactElement {
     onSignIn,
     onSignOut,
   } = useUserInfo();
-  const [classes, setClasses] = useState(new Map<string, SubscriptionCourse>());
+
+  // Represents a mapping of termId to a mapping of courseCode to SubscriptionCourse
+  // Example:
+  // {
+  //   "202530": {
+  //     'CS2500': SubscriptionCourse,
+  //     'COMM1100': SubscriptionCourse,
+  //   },
+  //   "202510": {
+  //     'CS2500': SubscriptionCourse,
+  //     'MATH1341': SubscriptionCourse,
+  //   },
+  // }
+  // When displayed, its most recent semester first (highest termId), then courses in alphabetical order
+  const [classes, setClasses] = useState(
+    new Map<string, Map<string, SubscriptionCourse>>()
+  );
 
   // is the course / section data still fetching
   const [isFetching, setIsFetching] = useState(true);
@@ -136,7 +165,7 @@ export default function SubscriptionsPage(): ReactElement {
       return;
     }
 
-    const classMapping = new Map<string, SubscriptionCourse>();
+    const classMapping = new Map<string, Map<string, SubscriptionCourse>>();
     const fetchSubscriptions = async (): Promise<void> => {
       try {
         await fetchCourseNotifs(classMapping, userInfo.courseIds);
@@ -155,10 +184,9 @@ export default function SubscriptionsPage(): ReactElement {
   }, [userInfo?.phoneNumber, isUserInfoLoading]);
 
   const unsubscribeAll = () => {
-    const allSections = Array.from(classes.values()).flatMap(
-      (course) => course.sections
+    const allSections = Array.from(classes.values()).flatMap((courseMap) =>
+      Array.from(courseMap.values()).flatMap((course) => course.sections)
     );
-
     axios
       .delete(`${process.env.NEXT_PUBLIC_NOTIFS_ENDPOINT}/user/subscriptions`, {
         data: {
@@ -210,9 +238,7 @@ export default function SubscriptionsPage(): ReactElement {
           <div className="Results_MainWrapper">
             <div className="Results_Main">
               <div className="Subscriptions_Header_Container">
-                <h2 className="Subscriptions_Title">
-                  {termName} Notifications
-                </h2>
+                <h2 className="Subscriptions_Title">Notifications</h2>
                 <button
                   className="Unsubscribe_All_Button"
                   onClick={unsubscribeAll}
@@ -221,17 +247,26 @@ export default function SubscriptionsPage(): ReactElement {
                   Unsubscribe All
                 </button>
               </div>
-              {Array.from(classes)
-                .sort((a, b) => (a > b ? 1 : -1))
-                .map(([courseCode, course]) => (
-                  <ClassCard
-                    key={courseCode}
-                    course={course}
-                    sections={course.sections}
-                    userInfo={userInfo}
-                    fetchUserInfo={fetchUserInfo}
-                    onSignIn={onSignIn}
-                  />
+              {/* Sort termId keys and iterate over them */}
+              {Array.from(classes.keys())
+                .sort((a, b) => parseInt(b) - parseInt(a)) // Sort termIds in descending order
+                .map((termId) => (
+                  <div key={termId}>
+                    <h3>{getTermName(termInfos, termId)}</h3>
+                    {/* Get the courses map for this termId and sort courses */}
+                    {Array.from(classes.get(termId)!.entries())
+                      .sort(([codeA], [codeB]) => codeA.localeCompare(codeB)) // Sort courses by courseCode
+                      .map(([courseCode, course]) => (
+                        <ClassCard
+                          key={courseCode}
+                          course={course}
+                          sections={course.sections}
+                          userInfo={userInfo}
+                          fetchUserInfo={fetchUserInfo}
+                          onSignIn={onSignIn}
+                        />
+                      ))}
+                  </div>
                 ))}
             </div>
           </div>

--- a/pages/subscriptions.tsx
+++ b/pages/subscriptions.tsx
@@ -27,7 +27,7 @@ async function fetchCourseNotifs(termMapping, courseIds) {
     const host = result.classByHash.host;
     const termId = result.classByHash.termId;
 
-    const filteredSections = result.classByHash.sections.map((s) => {
+    const formattedSections = result.classByHash.sections.map((s) => {
       return {
         ...s,
         online: false,
@@ -39,7 +39,7 @@ async function fetchCourseNotifs(termMapping, courseIds) {
     });
 
     // If no sections are available, skip this course
-    if (filteredSections.length === 0) {
+    if (formattedSections.length === 0) {
       continue;
     }
 
@@ -55,7 +55,7 @@ async function fetchCourseNotifs(termMapping, courseIds) {
       host: host,
       name: result.classByHash.name,
       lastUpdateTime: result.classByHash.lastUpdateTime,
-      sections: filteredSections,
+      sections: formattedSections,
     });
   }
 }
@@ -89,7 +89,7 @@ async function fetchSectionNotifs(termMapping, sectionIds) {
 
     // If course has already been found in fetchCourseNotifs(), continue
     if (!classMap.has(courseCode)) {
-      const filteredSections = courseResult.classByHash.sections.map((s) => {
+      const formattedSections = courseResult.classByHash.sections.map((s) => {
         return {
           ...s,
           online: false,
@@ -101,7 +101,7 @@ async function fetchSectionNotifs(termMapping, sectionIds) {
       });
 
       // If no sections are available, skip this course
-      if (filteredSections.length === 0) {
+      if (formattedSections.length === 0) {
         continue;
       }
 
@@ -112,7 +112,7 @@ async function fetchSectionNotifs(termMapping, sectionIds) {
         host: host,
         name: courseResult.classByHash.name,
         lastUpdateTime: courseResult.classByHash.lastUpdateTime,
-        sections: filteredSections,
+        sections: formattedSections,
       });
     }
   }

--- a/styles/_EmptyCard.scss
+++ b/styles/_EmptyCard.scss
@@ -71,7 +71,7 @@
       gap: 14px;
 
       .Empty_Main__EmptyCard_Text_Body {
-        line-height: 10px;
+        line-height: 16px;
       }
     }
 
@@ -130,7 +130,7 @@
 
       &_Title {
         font-style: normal;
-        line-height: 13px;
+        line-height: 20px;
         font-size: 18px;
 
         b {

--- a/styles/pages/_Results.scss
+++ b/styles/pages/_Results.scss
@@ -180,6 +180,7 @@ $SIDEBAR_WIDTH: 268px;
     justify-content: space-between;
     align-items: end;
     flex-direction: row;
+    margin-bottom: 16px;
 
     .Subscriptions_Title {
       font-family: Lato;


### PR DESCRIPTION
# Purpose

_In 2-3 sentences - what does this code actually do, and why?_

Fixes the notification toggle by having it so if a user is subscribed it is always shown. If they are not subscribed, it is only shown if there are less than 1 seat available. Notification limits are respected on the subscriptions page.

# Tickets

_What Trello tickets (if any) are associated with this PR?_

- https://github.com/sandboxnu/searchneu/issues/329

# Contributors

_Who worked on this PR? Tag them with their Github `@username` for future reference_

@ItsEricSun 

# Feature List

_Expand on the purpose - what does this code do, and how? This should be a list of the changes, more in-depth and technical_

- 12 notif limit is respected on both search page and subscriptions page
- Users can't get around the limit by having multiple pages open (before actually subscribing, an extra call to the backend to get count of subscriptions was added to prevent this)
- If the termId can't be found in the router, it is fetched from the course or section info, which makes the subscription page follow limit
- Tooltips now appear when hovering over a disabled Course notif switch
- On subscriptions page, if there are multiple active terms, it will display each one of them with their own sections, with each term having its own 12 notif limit
- All sections will always be shown on subscriptions page
- Updated the text and styling for the card that is displayed on subscriptions page when no notifs so that text aren't overlapping

# Pictures

_If there are visual changes, show a before/after view, and add a link to the after view using the staging environment._

If section has at least 1 seat available, don't let user subscribe.
![image](https://github.com/user-attachments/assets/3a24f6d6-b294-470a-a36e-0c862c1e9960)

If they are subscribed, switch will always show up no matter how many seats available.
![image](https://github.com/user-attachments/assets/623221f1-6786-4f01-91be-bdac222ec663)
And once they unsubscribe, switch disappears.
![image](https://github.com/user-attachments/assets/186dde9d-8ead-4b59-ae1e-a616d3d5c26e)

Course notif has tooltips
![image](https://github.com/user-attachments/assets/7a167157-82f0-4a47-a0d5-984b0dede028)

What updated subscriptions page looks like (and don't worry about it showing inactive Fall 2024 notifs, updated backend to return all semesters including inactive ones to test)
![image](https://github.com/user-attachments/assets/c5bdc0a4-76bf-4ba5-8ac2-cefdfe5deb6f)
It respects limit
![image](https://github.com/user-attachments/assets/40f449a3-03ee-4ca0-8a9d-2003d83c44cb)

EmptyCard before:
![image](https://github.com/user-attachments/assets/0719e2ba-2f7c-4e16-88fb-4c2aedd7a28d)
After:
![image](https://github.com/user-attachments/assets/dd281c87-a518-4b8c-9c98-e57e1c365907)


# Reviewers

**Primary**:

@mehallhm 
@ananyaspatil 

**Secondary**:

@cherman23 
@nick-pfeiffer 
@WesleyTran0 
