### PR TITLE
Along with ticket #284 to allow for access of active (boolean)

### DIFF
--- a/components/terms.ts
+++ b/components/terms.ts
@@ -9,6 +9,7 @@ export interface TermInfo {
   /** Term ID */
   value: string;
   href: string;
+  active: boolean;
 }
 
 /**
@@ -43,6 +44,7 @@ export async function fetchTermInfo(): Promise<{
             text: term['text'],
             value: term['termId'],
             href: `/${college}/${term['termId']}`,
+            active: term['active'],
           };
         }
       );

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -208,6 +208,7 @@ export type TermInfo = {
   termId: Scalars['String'];
   subCollege: Scalars['String'];
   text: Scalars['String'];
+  active: Scalars['Boolean'];
 };
 
 export type GetCourseInfoByHashQueryVariables = Exact<{
@@ -476,7 +477,7 @@ export type GetTermIDsByCollegeQueryVariables = Exact<{
 
 export type GetTermIDsByCollegeQuery = { __typename?: 'Query' } & {
   termInfos: Array<
-    { __typename?: 'TermInfo' } & Pick<TermInfo, 'text' | 'termId'>
+    { __typename?: 'TermInfo' } & Pick<TermInfo, 'text' | 'termId' | 'active'>
   >;
 };
 
@@ -701,6 +702,7 @@ export const GetTermIDsByCollegeDocument = gql`
     termInfos(subCollege: $subCollege) {
       text
       termId
+      active
     }
   }
 `;

--- a/pages/api/termIdsByCollege.graphql
+++ b/pages/api/termIdsByCollege.graphql
@@ -2,5 +2,6 @@ query getTermIDsByCollege($subCollege: String!) {
   termInfos(subCollege: $subCollege) {
     text
     termId
+    active
   }
 }


### PR DESCRIPTION
# Purpose

Goes with #284 to allow for getting the active boolean of termInfo

# Tickets

#284, #281


# Feature List

- Adds the active field in TermInfo

# Pictures

_If there are visual changes, show a before/after view, and add a link to the after view using the staging environment._

# Reviewers

Primary reviewer:

**Primary**: @mehallhm @ananyaspatil 

Use the **"Reviewers"** feature in Github

Secondary reviewers:

**Secondary**: @cherman23 @ItsEricSun @nick-pfeiffer 
